### PR TITLE
Fix account deletion and email verification URLs

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -114,6 +114,11 @@ func configureSMTP(app core.App) {
 		}
 	}
 
+	// AppURL is used by PocketBase email templates ({APP_URL} placeholder)
+	if appURL := os.Getenv("APP_URL"); appURL != "" {
+		settings.Meta.AppURL = appURL
+	}
+
 	if err := app.Save(settings); err != nil {
 		app.Logger().Warn("could not save SMTP config", slog.Any("error", err))
 	} else {

--- a/backend/hooks/users.go
+++ b/backend/hooks/users.go
@@ -42,15 +42,16 @@ func RegisterUserHooks(app *pocketbase.PocketBase) {
 	})
 
 	// Users: cascade delete all related data (GDPR Art. 17)
+	// IMPORTANT: cascade MUST run before e.Next() because related
+	// collections have Required:true relations to users — PocketBase
+	// blocks the user delete if any referencing records still exist.
 	app.OnRecordDelete("users").BindFunc(func(e *core.RecordEvent) error {
-		if err := e.Next(); err != nil {
-			return err
-		}
 		userId := e.Record.Id
+
+		// Delete records that reference users directly
 		collections := []string{
 			"sms_messages", "sms_devices", "webhook_configs",
-			"api_keys", "user_quotas", "subscriptions",
-			"payments", "sms_templates", "scheduled_sms",
+			"api_keys", "user_quotas", "sms_templates", "scheduled_sms",
 		}
 		for _, col := range collections {
 			records, err := e.App.FindRecordsByFilter(col, "user = {:uid}", "", 0, 0, dbx.Params{"uid": userId})
@@ -58,7 +59,6 @@ func RegisterUserHooks(app *pocketbase.PocketBase) {
 				continue
 			}
 			for _, r := range records {
-				// For webhook_configs, also delete their delivery logs
 				if col == "webhook_configs" {
 					logs, _ := e.App.FindRecordsByFilter("webhook_delivery_logs", "webhook = {:wid}", "", 0, 0, dbx.Params{"wid": r.Id})
 					for _, l := range logs {
@@ -68,7 +68,20 @@ func RegisterUserHooks(app *pocketbase.PocketBase) {
 				_ = e.App.Delete(r)
 			}
 		}
+
+		// Delete subscriptions and their payments (payments link via subscription, not user)
+		subscriptions, err := e.App.FindRecordsByFilter("subscriptions", "user = {:uid}", "", 0, 0, dbx.Params{"uid": userId})
+		if err == nil {
+			for _, sub := range subscriptions {
+				payments, _ := e.App.FindRecordsByFilter("payments", "subscription = {:sid}", "", 0, 0, dbx.Params{"sid": sub.Id})
+				for _, p := range payments {
+					_ = e.App.Delete(p)
+				}
+				_ = e.App.Delete(sub)
+			}
+		}
+
 		e.App.Logger().Info("Cascade deleted user data", slog.String("user", userId))
-		return nil
+		return e.Next()
 	})
 }


### PR DESCRIPTION
- Move cascade delete before e.Next() — PocketBase blocks user deletion when Required:true relations still reference the user (GDPR Art. 17)
- Fix payments deletion which goes through subscription, not user
- Set Meta.AppURL from APP_URL env so email links use the public host instead of defaulting to localhost:8090