### PR TITLE
Fix password validation mismatch between frontend (8 chars)

### DIFF
--- a/frontend/src/components/UserSettings/ChangePassword.tsx
+++ b/frontend/src/components/UserSettings/ChangePassword.tsx
@@ -19,11 +19,11 @@ const formSchema = z
     current_password: z
       .string()
       .min(1, { message: "Password is required" })
-      .min(8, { message: "Password must be at least 8 characters" }),
+      .min(10, { message: "Password must be at least 10 characters" }),
     new_password: z
       .string()
       .min(1, { message: "Password is required" })
-      .min(8, { message: "Password must be at least 8 characters" }),
+      .min(10, { message: "Password must be at least 10 characters" }),
     confirm_password: z
       .string()
       .min(1, { message: "Password confirmation is required" }),

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -26,6 +26,17 @@ function extractErrorMessage(err: unknown): string {
       if (data.detail && typeof data.detail === "string") {
         return data.detail
       }
+      // PocketBase field-level validation errors: { fieldName: { code, message } }
+      const fieldError = Object.values(data).find(
+        (v): v is { message: string } =>
+          typeof v === "object" &&
+          v !== null &&
+          "message" in v &&
+          typeof (v as { message: unknown }).message === "string",
+      )
+      if (fieldError) {
+        return fieldError.message
+      }
     }
     if (pbError.response?.message) {
       return pbError.response.message

--- a/frontend/src/routes/reset-password.tsx
+++ b/frontend/src/routes/reset-password.tsx
@@ -33,7 +33,7 @@ const formSchema = z
     new_password: z
       .string()
       .min(1, { message: "Password is required" })
-      .min(8, { message: "Password must be at least 8 characters" }),
+      .min(10, { message: "Password must be at least 10 characters" }),
     confirm_password: z
       .string()
       .min(1, { message: "Password confirmation is required" }),

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -31,7 +31,7 @@ const formSchema = z
     password: z
       .string()
       .min(1, { message: "Password is required" })
-      .min(8, { message: "Password must be at least 8 characters" }),
+      .min(10, { message: "Password must be at least 10 characters" }),
     confirm_password: z
       .string()
       .min(1, { message: "Password confirmation is required" }),


### PR DESCRIPTION
Fix password validation mismatch between frontend (8 chars) and backend (10 chars)

Also fix extractErrorMessage to surface PocketBase field-level validation errors instead of the generic "Failed to create record." message.