### PR TITLE
Add related repositories section to READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -223,6 +223,17 @@ npx playwright test --ui
 - **Releases**: Crear un tag (`git tag v0.1.0 && git push --tags`) para publicar imagen Docker en GHCR y compilar binarios Go vía GoReleaser
 - **Modem Agent**: Crear un tag (`git tag modem-agent/v0.1.0 && git push --tags`) para compilar binarios del modem agent
 
+## Repositorios Relacionados
+
+| Repositorio | Descripción |
+|-------------|-------------|
+| [vendel-homepage](https://github.com/JimScope/vendel-homepage) | Landing page y sistema de diseño |
+| [vendel-android](https://github.com/JimScope/vendel-android) | App Android (gateway de dispositivo) |
+| [vendel-mcp](https://github.com/JimScope/vendel-mcp) | Servidor MCP para asistentes de IA |
+| [vendel-sdk-js](https://github.com/JimScope/vendel-sdk-js) | SDK JavaScript/TypeScript (`vendel-sdk` en npm) |
+| [vendel-sdk-python](https://github.com/JimScope/vendel-sdk-python) | SDK Python (`vendel-sdk` en PyPI) |
+| [vendel-sdk-go](https://github.com/JimScope/vendel-sdk-go) | SDK Go (Go modules) |
+
 ## Licencia
 
 MIT License

--- a/README.md
+++ b/README.md
@@ -223,6 +223,17 @@ npx playwright test --ui
 - **Releases**: Create a tag (`git tag v0.1.0 && git push --tags`) to publish a Docker image to GHCR and build Go binaries via GoReleaser
 - **Modem Agent**: Create a tag (`git tag modem-agent/v0.1.0 && git push --tags`) to build modem agent binaries
 
+## Related Repositories
+
+| Repository | Description |
+|------------|-------------|
+| [vendel-homepage](https://github.com/JimScope/vendel-homepage) | Landing page and design system |
+| [vendel-android](https://github.com/JimScope/vendel-android) | Android app (device gateway) |
+| [vendel-mcp](https://github.com/JimScope/vendel-mcp) | MCP server for AI assistants |
+| [vendel-sdk-js](https://github.com/JimScope/vendel-sdk-js) | JavaScript/TypeScript SDK (`vendel-sdk` on npm) |
+| [vendel-sdk-python](https://github.com/JimScope/vendel-sdk-python) | Python SDK (`vendel-sdk` on PyPI) |
+| [vendel-sdk-go](https://github.com/JimScope/vendel-sdk-go) | Go SDK (Go modules) |
+
 ## License
 
 MIT License


### PR DESCRIPTION
## Summary
- Add "Related Repositories" / "Repositorios Relacionados" section to both English and Spanish READMEs
- Lists all ecosystem repos: homepage, Android app, MCP server, and SDKs (JS, Python, Go)

## Test plan
- [ ] Verify links render correctly on GitHub
- [ ] Confirm all 6 repo URLs are valid