### PR TITLE
Add modem-agent documentation to READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -99,6 +99,7 @@ vendel/
 │   │   ├── hooks/              # Hooks custom (PocketBase SDK)
 │   │   └── lib/pocketbase.ts   # Cliente PocketBase
 │   └── tests/                  # Tests Playwright
+├── modem-agent/                # Agente Go para módems USB (AT commands)
 ├── Dockerfile                  # Multi-stage (node + go + alpine)
 ├── docker-compose.yml
 ├── litestream.yml              # Config de replicación Litestream (opt-in)
@@ -159,6 +160,21 @@ npm run build
 
 # Tests E2E
 npx playwright test
+```
+
+#### Modem Agent
+
+El modem agent permite usar módems USB LTE/4G/5G con tarjeta SIM física como gateways de SMS — sin necesidad de un teléfono Android.
+
+```bash
+cd modem-agent
+
+# Configurar módems (formato: api_key:command_port[:notify_port], separados por coma)
+export VENDEL_URL=http://localhost:8090
+export MODEMS="tu_api_key_del_dispositivo:/dev/ttyUSB0:/dev/ttyUSB1"
+
+# Ejecutar
+go run .
 ```
 
 ## Configuración

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ vendel/
 │   │   ├── hooks/              # Custom React hooks (PocketBase SDK)
 │   │   └── lib/pocketbase.ts   # PocketBase client
 │   └── tests/                  # Playwright tests
+├── modem-agent/                # Go agent for USB modem gateways (AT commands)
 ├── Dockerfile                  # Multi-stage (node + go + alpine)
 ├── docker-compose.yml
 ├── litestream.yml              # Litestream replication config (opt-in)
@@ -159,6 +160,21 @@ npm run build
 
 # E2E tests
 npx playwright test
+```
+
+#### Modem Agent
+
+The modem agent allows using USB LTE/4G/5G modems with a physical SIM card as SMS gateways — no Android phone needed.
+
+```bash
+cd modem-agent
+
+# Configure modems (format: api_key:command_port[:notify_port], comma-separated)
+export VENDEL_URL=http://localhost:8090
+export MODEMS="your_device_api_key:/dev/ttyUSB0:/dev/ttyUSB1"
+
+# Run
+go run .
 ```
 
 ## Configuration


### PR DESCRIPTION
## Summary
- Add `modem-agent/` to the project structure tree in both READMEs
- Add a "Modem Agent" subsection under Manual Development with setup instructions
- Addresses the visibility gap noted in #108 — the modem-agent existed but wasn't documented in the public README

## Context
Issue #108 requested USB modem support, which already exists in `modem-agent/`. This PR makes it discoverable.

## Test plan
- [ ] Verify modem-agent appears in the project structure tree
- [ ] Verify setup instructions render correctly on GitHub