### PR TITLE
Strip secrets from admin API and add rate limits

### DIFF
--- a/backend/config.go
+++ b/backend/config.go
@@ -176,6 +176,13 @@ func configureRateLimits(app core.App) {
 		{Label: "POST /api/sms/fcm-token", MaxRequests: 10, Duration: 60},
 		{Label: "POST /api/sms/send", MaxRequests: 30, Duration: 60},
 		{Label: "GET /api/sms/pending", MaxRequests: 30, Duration: 60},
+		{Label: "GET /api/utils/app-settings", MaxRequests: 30, Duration: 60},
+		{Label: "POST /api/plans/topup", MaxRequests: 10, Duration: 60},
+		{Label: "PUT /api/plans/upgrade", MaxRequests: 5, Duration: 60},
+		{Label: "POST /api/contacts/import", MaxRequests: 5, Duration: 60},
+		{Label: "GET /api/system-config", MaxRequests: 10, Duration: 60},
+		{Label: "PUT /api/system-config", MaxRequests: 10, Duration: 60},
+		{Label: "POST /api/webhooks/", MaxRequests: 60, Duration: 60},
 		{Label: "/api/", MaxRequests: 300, Duration: 60},
 	}
 

--- a/backend/handlers/utils.go
+++ b/backend/handlers/utils.go
@@ -58,6 +58,20 @@ func RegisterUtilRoutes(se *core.ServeEvent) {
 			envHints[configKey] = os.Getenv(envKey) != ""
 		}
 
+		// Strip secret values — never return them, admin uses env_hints to know if set
+		secretKeys := map[string]bool{
+			"trondealer_api_key":        true,
+			"trondealer_webhook_secret": true,
+			"qvapay_app_secret":         true,
+			"stripe_secret_key":         true,
+			"stripe_webhook_secret":     true,
+		}
+		for _, r := range records {
+			if secretKeys[r.GetString("key")] {
+				r.Set("value", "")
+			}
+		}
+
 		return e.JSON(http.StatusOK, map[string]any{"data": records, "env_hints": envHints})
 	}).Bind(apis.RequireAuth("users"))
 
@@ -77,7 +91,16 @@ func RegisterUtilRoutes(se *core.ServeEvent) {
 			return apis.NewApiError(http.StatusInternalServerError, "system_config collection not found", nil)
 		}
 
+		secretKeys := map[string]bool{
+			"trondealer_api_key": true, "trondealer_webhook_secret": true,
+			"qvapay_app_secret": true, "stripe_secret_key": true, "stripe_webhook_secret": true,
+		}
+
 		for key, value := range body {
+			// Don't overwrite secrets with empty values (GET strips them)
+			if value == "" && secretKeys[key] {
+				continue
+			}
 			record, _ := e.App.FindFirstRecordByFilter("system_config", "key = {:key}", map[string]any{"key": key})
 			if record != nil {
 				record.Set("value", value)


### PR DESCRIPTION
## Summary
- GET /api/system-config no longer returns payment provider secret values
- PUT ignores empty values for secret keys to prevent accidental overwrites
- Added rate limits for public, payment, and admin endpoints

## Test plan
- [ ] Admin settings loads without showing secret values
- [ ] env_hints still shows green pills for configured env vars
- [ ] Saving config without touching secret fields preserves existing values
- [ ] Writing a new secret value works correctly