### PR TITLE
Add contacts, groups, vCard import and autocomplete

### DIFF
--- a/backend/handlers/contacts.go
+++ b/backend/handlers/contacts.go
@@ -1,0 +1,122 @@
+package handlers
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/pocketbase/dbx"
+	"github.com/pocketbase/pocketbase/apis"
+	"github.com/pocketbase/pocketbase/core"
+)
+
+var phoneCleanRegex = regexp.MustCompile(`[^\d+]`)
+
+// RegisterContactRoutes registers contact-related API routes.
+func RegisterContactRoutes(se *core.ServeEvent) {
+	// POST /api/contacts/import — import contacts from vCard (.vcf) file
+	se.Router.POST("/api/contacts/import", func(e *core.RequestEvent) error {
+		userId := e.Auth.Id
+
+		file, _, err := e.Request.FormFile("file")
+		if err != nil {
+			return apis.NewBadRequestError("File is required", nil)
+		}
+		defer file.Close()
+
+		groupId := e.Request.FormValue("group_id")
+
+		contacts := parseVCard(file)
+		if len(contacts) == 0 {
+			return apis.NewBadRequestError("No valid contacts found in file", nil)
+		}
+
+		collection, err := e.App.FindCollectionByNameOrId("contacts")
+		if err != nil {
+			return apis.NewApiError(http.StatusInternalServerError, "contacts collection not found", nil)
+		}
+
+		imported, skipped := 0, 0
+		for _, c := range contacts {
+			// Skip if phone already exists for this user
+			existing, _ := e.App.FindFirstRecordByFilter(
+				"contacts",
+				"user = {:userId} && phone_number = {:phone}",
+				dbx.Params{"userId": userId, "phone": c.phone},
+			)
+			if existing != nil {
+				skipped++
+				continue
+			}
+
+			record := core.NewRecord(collection)
+			record.Set("user", userId)
+			record.Set("name", c.name)
+			record.Set("phone_number", c.phone)
+			if groupId != "" {
+				record.Set("groups", []string{groupId})
+			}
+
+			if err := e.App.Save(record); err != nil {
+				skipped++
+				continue
+			}
+			imported++
+		}
+
+		return e.JSON(http.StatusOK, map[string]any{
+			"imported": imported,
+			"skipped":  skipped,
+			"total":    len(contacts),
+		})
+	}).Bind(apis.RequireAuth("users"))
+}
+
+type vcardEntry struct {
+	name  string
+	phone string
+}
+
+// parseVCard extracts name + phone from a vCard file.
+// Supports multiple contacts in a single .vcf file.
+func parseVCard(r io.Reader) []vcardEntry {
+	var entries []vcardEntry
+	var current vcardEntry
+	inCard := false
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		switch {
+		case line == "BEGIN:VCARD":
+			inCard = true
+			current = vcardEntry{}
+
+		case line == "END:VCARD":
+			if inCard && current.name != "" && current.phone != "" {
+				entries = append(entries, current)
+			}
+			inCard = false
+
+		case inCard && strings.HasPrefix(line, "FN:"):
+			current.name = strings.TrimPrefix(line, "FN:")
+
+		case inCard && strings.Contains(line, "TEL"):
+			// TEL:+123... or TEL;TYPE=CELL:+123... or TEL;TYPE=CELL;VALUE=uri:tel:+123...
+			phone := line
+			if idx := strings.LastIndex(phone, ":"); idx >= 0 {
+				phone = phone[idx+1:]
+			}
+			// Clean non-digit chars except +
+			phone = phoneCleanRegex.ReplaceAllString(phone, "")
+			if e164Regex.MatchString(phone) && current.phone == "" {
+				current.phone = phone
+			}
+		}
+	}
+
+	return entries
+}

--- a/backend/handlers/sms.go
+++ b/backend/handlers/sms.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/apis"
 	"github.com/pocketbase/pocketbase/core"
 )
@@ -25,9 +26,31 @@ func RegisterSMSRoutes(se *core.ServeEvent) {
 			Recipients []string `json:"recipients"`
 			Body       string   `json:"body"`
 			DeviceID   string   `json:"device_id"`
+			GroupID    string   `json:"group_id"`
 		}
 		if err := e.BindBody(&body); err != nil {
 			return apis.NewBadRequestError("Invalid request body", nil)
+		}
+
+		// Resolve group contacts into recipients
+		if body.GroupID != "" {
+			groupContacts, _ := e.App.FindRecordsByFilter(
+				"contacts",
+				"user = {:userId} && groups.id ?= {:groupId}",
+				"", 0, 0,
+				dbx.Params{"userId": userId, "groupId": body.GroupID},
+			)
+			seen := make(map[string]bool)
+			for _, r := range body.Recipients {
+				seen[r] = true
+			}
+			for _, c := range groupContacts {
+				phone := c.GetString("phone_number")
+				if !seen[phone] {
+					body.Recipients = append(body.Recipients, phone)
+					seen[phone] = true
+				}
+			}
 		}
 
 		if len(body.Recipients) == 0 {

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"vendel/commands"
 	"vendel/cronjobs"
 	"vendel/handlers"
 	"vendel/hooks"
@@ -20,9 +19,6 @@ import (
 	"github.com/pocketbase/pocketbase/core"
 	"github.com/pocketbase/pocketbase/plugins/migratecmd"
 )
-
-// version is set at build time via -ldflags "-X main.version=..."
-var version = "dev"
 
 func main() {
 	// Load .env file (from cwd or parent dir)
@@ -57,6 +53,7 @@ func main() {
 		handlers.RegisterUserWebhookRoutes(se)
 		handlers.RegisterWebhookRoutes(se)
 		handlers.RegisterApiKeyRoutes(se)
+		handlers.RegisterContactRoutes(se)
 		handlers.RegisterUtilRoutes(se)
 
 		// Global middleware
@@ -81,9 +78,6 @@ func main() {
 
 	// ── Cron jobs ────────────────────────────────────────────────────
 	cronjobs.RegisterCronJobs(app)
-
-	// ── CLI commands ─────────────────────────────────────────────────
-	app.RootCmd.AddCommand(commands.NewUpdateCommand(version))
 
 	// ── Start ────────────────────────────────────────────────────────
 	if err := app.Start(); err != nil {

--- a/backend/migrations/1740000016_add_contacts.go
+++ b/backend/migrations/1740000016_add_contacts.go
@@ -1,0 +1,94 @@
+package migrations
+
+import (
+	"github.com/pocketbase/pocketbase/core"
+	m "github.com/pocketbase/pocketbase/migrations"
+)
+
+func init() {
+	m.Register(func(app core.App) error {
+		users, err := app.FindCollectionByNameOrId("users")
+		if err != nil {
+			return err
+		}
+
+		// ── contact_groups ──────────────────────────────────────────
+		groups := core.NewBaseCollection("contact_groups")
+		groups.Fields.Add(
+			&core.AutodateField{Name: "created", OnCreate: true},
+			&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true},
+			&core.RelationField{
+				Name:         "user",
+				CollectionId: users.Id,
+				Required:     true,
+				MaxSelect:    1,
+			},
+			&core.TextField{
+				Name:     "name",
+				Required: true,
+				Max:      100,
+			},
+		)
+		groups.ListRule = ptrStr("user = @request.auth.id")
+		groups.ViewRule = ptrStr("user = @request.auth.id")
+		groups.CreateRule = ptrStr("@request.auth.id != ''")
+		groups.UpdateRule = ptrStr("user = @request.auth.id")
+		groups.DeleteRule = ptrStr("user = @request.auth.id")
+		groups.AddIndex("idx_contact_groups_user_name", true, "user, name", "")
+
+		if err := app.Save(groups); err != nil {
+			return err
+		}
+
+		// ── contacts ────────────────────────────────────────────────
+		contacts := core.NewBaseCollection("contacts")
+		contacts.Fields.Add(
+			&core.AutodateField{Name: "created", OnCreate: true},
+			&core.AutodateField{Name: "updated", OnCreate: true, OnUpdate: true},
+			&core.RelationField{
+				Name:         "user",
+				CollectionId: users.Id,
+				Required:     true,
+				MaxSelect:    1,
+			},
+			&core.TextField{
+				Name:     "name",
+				Required: true,
+				Max:      200,
+			},
+			&core.TextField{
+				Name:     "phone_number",
+				Required: true,
+				Max:      20,
+				Pattern:  `^\+[1-9]\d{1,14}$`,
+			},
+			&core.RelationField{
+				Name:         "groups",
+				CollectionId: groups.Id,
+				MaxSelect:    50,
+			},
+			&core.TextField{
+				Name: "notes",
+				Max:  500,
+			},
+		)
+		contacts.ListRule = ptrStr("user = @request.auth.id")
+		contacts.ViewRule = ptrStr("user = @request.auth.id")
+		contacts.CreateRule = ptrStr("@request.auth.id != ''")
+		contacts.UpdateRule = ptrStr("user = @request.auth.id")
+		contacts.DeleteRule = ptrStr("user = @request.auth.id")
+		contacts.AddIndex("idx_contacts_user_phone", true, "user, phone_number", "")
+		contacts.AddIndex("idx_contacts_user", false, "user", "")
+
+		return app.Save(contacts)
+	}, func(app core.App) error {
+		// Rollback
+		if col, err := app.FindCollectionByNameOrId("contacts"); err == nil {
+			_ = app.Delete(col)
+		}
+		if col, err := app.FindCollectionByNameOrId("contact_groups"); err == nil {
+			_ = app.Delete(col)
+		}
+		return nil
+	})
+}

--- a/frontend/src/components/Common/AnnouncementBanner.tsx
+++ b/frontend/src/components/Common/AnnouncementBanner.tsx
@@ -40,9 +40,9 @@ function AnnouncementBanner() {
   )
 
   return (
-    <div className="flex w-full items-center gap-2 bg-brand px-4 py-2 text-sm text-neutral-900 dark:text-neutral-900">
-      <Megaphone className="size-4 shrink-0" />
-      <p className="min-w-0 flex-1 truncate">{content}</p>
+    <div className="flex w-full items-start gap-2 bg-brand px-4 py-2 text-sm text-neutral-900 dark:text-neutral-900">
+      <Megaphone className="mt-0.5 size-4 shrink-0" />
+      <p className="min-w-0 flex-1">{content}</p>
       <button
         type="button"
         onClick={handleDismiss}

--- a/frontend/src/components/Common/Footer.tsx
+++ b/frontend/src/components/Common/Footer.tsx
@@ -1,4 +1,6 @@
+import { Heart } from "lucide-react"
 import { FaGithub } from "react-icons/fa"
+import useAppConfig from "@/hooks/useAppConfig"
 
 const socialLinks = [
   {
@@ -10,12 +12,26 @@ const socialLinks = [
 
 export function Footer() {
   const currentYear = new Date().getFullYear()
+  const { config } = useAppConfig()
 
   return (
     <footer className="border-t py-4 px-6">
       <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
-        <p className="text-muted-foreground text-sm">Vendel - {currentYear}</p>
+        <div className="flex flex-col items-center gap-1 sm:items-start">
+          <p className="text-muted-foreground text-sm">Vendel - {currentYear}</p>
+          <p className="flex items-center gap-1 text-xs text-muted-foreground">
+            Hecho con <Heart className="size-3 fill-red-500 text-red-500" /> desde Cuba
+          </p>
+        </div>
         <div className="flex items-center gap-4">
+          {config.supportEmail && config.supportEmail !== "support@example.com" && (
+            <a
+              href={`mailto:${config.supportEmail}`}
+              className="text-muted-foreground hover:text-foreground transition-colors text-sm"
+            >
+              {config.supportEmail}
+            </a>
+          )}
           {socialLinks.map(({ icon: Icon, href, label }) => (
             <a
               key={label}

--- a/frontend/src/components/Contacts/AddContact.tsx
+++ b/frontend/src/components/Contacts/AddContact.tsx
@@ -1,0 +1,221 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Plus } from "lucide-react"
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { z } from "zod"
+
+import { MultiSelect } from "@/components/Common/MultiSelect"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { LoadingButton } from "@/components/ui/loading-button"
+import { Textarea } from "@/components/ui/textarea"
+import { useContactGroupList } from "@/hooks/useContactGroupList"
+import { useCreateContact } from "@/hooks/useContactMutations"
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(1, { message: "Name is required" })
+    .max(255, { message: "Name must be at most 255 characters" }),
+  phone_number: z
+    .string()
+    .min(1, { message: "Phone number is required" })
+    .max(20, { message: "Phone number must be at most 20 characters" }),
+  groups: z.array(z.string()).optional(),
+  notes: z.string().max(1000).optional(),
+})
+
+type FormData = z.infer<typeof formSchema>
+
+interface AddContactProps {
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}
+
+const AddContact = ({ open, onOpenChange }: AddContactProps) => {
+  const { t } = useTranslation()
+  const [internalOpen, setInternalOpen] = useState(false)
+  const isOpen = open ?? internalOpen
+  const setIsOpen = onOpenChange ?? setInternalOpen
+  const { data: groups } = useContactGroupList()
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    mode: "onBlur",
+    criteriaMode: "all",
+    defaultValues: {
+      name: "",
+      phone_number: "",
+      groups: [],
+      notes: "",
+    },
+  })
+
+  const createContactMutation = useCreateContact()
+
+  const onSubmit = (data: FormData) => {
+    createContactMutation.mutate(
+      {
+        name: data.name,
+        phone_number: data.phone_number,
+        groups: data.groups,
+        notes: data.notes,
+      },
+      {
+        onSuccess: () => {
+          form.reset()
+          setIsOpen(false)
+        },
+      },
+    )
+  }
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      form.reset()
+    }
+    setIsOpen(open)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogTrigger asChild>
+        <Button className="my-4">
+          <Plus />
+          {t("contacts.addContact")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent
+        className="sm:max-w-md"
+        onInteractOutside={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle>{t("contacts.addContact")}</DialogTitle>
+          <DialogDescription>{t("contacts.description")}</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="grid gap-4 py-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("contacts.name")}{" "}
+                      <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder="John Doe" type="text" {...field} required />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="phone_number"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("contacts.phoneNumber")}{" "}
+                      <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="+1234567890"
+                        type="tel"
+                        {...field}
+                        required
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="groups"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("contacts.groups")}</FormLabel>
+                    <FormControl>
+                      <MultiSelect
+                        options={(groups?.data || []).map((group) => ({
+                          label: group.name,
+                          value: group.id,
+                        }))}
+                        onValueChange={field.onChange}
+                        defaultValue={field.value || []}
+                        placeholder={t("contacts.groups")}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="notes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("contacts.notes")}</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder={t("contacts.notes")}
+                        rows={2}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button
+                  variant="outline"
+                  disabled={createContactMutation.isPending}
+                >
+                  {t("common.cancel")}
+                </Button>
+              </DialogClose>
+              <LoadingButton
+                type="submit"
+                loading={createContactMutation.isPending}
+              >
+                {t("common.create")}
+              </LoadingButton>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AddContact

--- a/frontend/src/components/Contacts/AddGroup.tsx
+++ b/frontend/src/components/Contacts/AddGroup.tsx
@@ -1,0 +1,133 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { FolderPlus } from "lucide-react"
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { z } from "zod"
+
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { LoadingButton } from "@/components/ui/loading-button"
+import { useCreateContactGroup } from "@/hooks/useContactGroupMutations"
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(1, { message: "Name is required" })
+    .max(255, { message: "Name must be at most 255 characters" }),
+})
+
+type FormData = z.infer<typeof formSchema>
+
+const AddGroup = () => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    mode: "onBlur",
+    criteriaMode: "all",
+    defaultValues: {
+      name: "",
+    },
+  })
+
+  const createGroupMutation = useCreateContactGroup()
+
+  const onSubmit = (data: FormData) => {
+    createGroupMutation.mutate(data, {
+      onSuccess: () => {
+        form.reset()
+        setIsOpen(false)
+      },
+    })
+  }
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      form.reset()
+    }
+    setIsOpen(open)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <FolderPlus className="size-4" />
+          {t("contacts.addGroup")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("contacts.addGroup")}</DialogTitle>
+          <DialogDescription>{t("contacts.description")}</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <div className="grid gap-4 py-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("contacts.groupName")}{" "}
+                      <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder={t("contacts.groupName")}
+                        type="text"
+                        {...field}
+                        required
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button
+                  variant="outline"
+                  disabled={createGroupMutation.isPending}
+                >
+                  {t("common.cancel")}
+                </Button>
+              </DialogClose>
+              <LoadingButton
+                type="submit"
+                loading={createGroupMutation.isPending}
+              >
+                {t("common.create")}
+              </LoadingButton>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AddGroup

--- a/frontend/src/components/Contacts/ContactActionsMenu.tsx
+++ b/frontend/src/components/Contacts/ContactActionsMenu.tsx
@@ -1,0 +1,34 @@
+import { EllipsisVertical } from "lucide-react"
+import { useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import type { Contact } from "@/types/collections"
+import DeleteContact from "./DeleteContact"
+import EditContact from "./EditContact"
+
+interface ContactActionsMenuProps {
+  contact: Contact
+}
+
+export const ContactActionsMenu = ({ contact }: ContactActionsMenuProps) => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon">
+          <EllipsisVertical />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <EditContact contact={contact} onSuccess={() => setOpen(false)} />
+        <DeleteContact id={contact.id} onSuccess={() => setOpen(false)} />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/Contacts/DeleteContact.tsx
+++ b/frontend/src/components/Contacts/DeleteContact.tsx
@@ -1,0 +1,33 @@
+import { useTranslation } from "react-i18next"
+
+import ConfirmDeleteDialog from "@/components/Common/ConfirmDeleteDialog"
+import { useDeleteContact } from "@/hooks/useContactMutations"
+
+interface DeleteContactProps {
+  id: string
+  onSuccess: () => void
+}
+
+const DeleteContact = ({ id, onSuccess }: DeleteContactProps) => {
+  const { t } = useTranslation()
+  const mutation = useDeleteContact()
+
+  return (
+    <ConfirmDeleteDialog
+      triggerLabel={t("contacts.deleteContact")}
+      title={t("contacts.deleteContact")}
+      description={t("contacts.deleteContactDesc")}
+      isPending={mutation.isPending}
+      onConfirm={(close) => {
+        mutation.mutate(id, {
+          onSuccess: () => {
+            close()
+            onSuccess()
+          },
+        })
+      }}
+    />
+  )
+}
+
+export default DeleteContact

--- a/frontend/src/components/Contacts/EditContact.tsx
+++ b/frontend/src/components/Contacts/EditContact.tsx
@@ -1,0 +1,205 @@
+import { zodResolver } from "@hookform/resolvers/zod"
+import { Pencil } from "lucide-react"
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { useTranslation } from "react-i18next"
+import { z } from "zod"
+
+import { MultiSelect } from "@/components/Common/MultiSelect"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { LoadingButton } from "@/components/ui/loading-button"
+import { Textarea } from "@/components/ui/textarea"
+import { useContactGroupList } from "@/hooks/useContactGroupList"
+import { useUpdateContact } from "@/hooks/useContactMutations"
+import type { Contact } from "@/types/collections"
+
+const formSchema = z.object({
+  name: z
+    .string()
+    .min(1, { message: "Name is required" })
+    .max(255, { message: "Name must be at most 255 characters" }),
+  phone_number: z
+    .string()
+    .min(1, { message: "Phone number is required" })
+    .max(20, { message: "Phone number must be at most 20 characters" }),
+  groups: z.array(z.string()).optional(),
+  notes: z.string().max(1000).optional(),
+})
+
+type FormData = z.infer<typeof formSchema>
+
+interface EditContactProps {
+  contact: Contact
+  onSuccess: () => void
+}
+
+const EditContact = ({ contact, onSuccess }: EditContactProps) => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const { data: groups } = useContactGroupList()
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(formSchema),
+    mode: "onBlur",
+    criteriaMode: "all",
+    defaultValues: {
+      name: contact.name,
+      phone_number: contact.phone_number,
+      groups: contact.groups || [],
+      notes: contact.notes || "",
+    },
+  })
+
+  const updateContactMutation = useUpdateContact(contact.id)
+
+  const onSubmit = (data: FormData) => {
+    updateContactMutation.mutate(data, {
+      onSuccess: () => {
+        setIsOpen(false)
+        onSuccess()
+      },
+    })
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DropdownMenuItem
+        onSelect={(e) => e.preventDefault()}
+        onClick={() => setIsOpen(true)}
+      >
+        <Pencil />
+        {t("contacts.editContact")}
+      </DropdownMenuItem>
+      <DialogContent className="sm:max-w-md">
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogHeader>
+              <DialogTitle>{t("contacts.editContact")}</DialogTitle>
+              <DialogDescription>
+                {t("contacts.description")}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-4 py-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("contacts.name")}{" "}
+                      <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input placeholder="John Doe" type="text" {...field} required />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="phone_number"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("contacts.phoneNumber")}{" "}
+                      <span className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="+1234567890"
+                        type="tel"
+                        {...field}
+                        required
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="groups"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("contacts.groups")}</FormLabel>
+                    <FormControl>
+                      <MultiSelect
+                        options={(groups?.data || []).map((group) => ({
+                          label: group.name,
+                          value: group.id,
+                        }))}
+                        onValueChange={field.onChange}
+                        defaultValue={field.value || []}
+                        placeholder={t("contacts.groups")}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="notes"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("contacts.notes")}</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder={t("contacts.notes")}
+                        rows={2}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button
+                  variant="outline"
+                  disabled={updateContactMutation.isPending}
+                >
+                  {t("common.cancel")}
+                </Button>
+              </DialogClose>
+              <LoadingButton
+                type="submit"
+                loading={updateContactMutation.isPending}
+              >
+                {t("common.save")}
+              </LoadingButton>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default EditContact

--- a/frontend/src/components/Contacts/ImportContacts.tsx
+++ b/frontend/src/components/Contacts/ImportContacts.tsx
@@ -1,0 +1,137 @@
+import { Upload } from "lucide-react"
+import { useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { MultiSelect } from "@/components/Common/MultiSelect"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { LoadingButton } from "@/components/ui/loading-button"
+import { useContactGroupList } from "@/hooks/useContactGroupList"
+import { useContactImport } from "@/hooks/useContactImport"
+import useCustomToast from "@/hooks/useCustomToast"
+
+const ImportContacts = () => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const [file, setFile] = useState<File | null>(null)
+  const [selectedGroups, setSelectedGroups] = useState<string[]>([])
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const { data: groups } = useContactGroupList()
+  const importMutation = useContactImport()
+  const { showSuccessToast } = useCustomToast()
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = e.target.files?.[0]
+    if (selected) {
+      setFile(selected)
+    }
+  }
+
+  const handleImport = () => {
+    if (!file) return
+
+    importMutation.mutate(
+      {
+        file,
+        groupId: selectedGroups[0],
+      },
+      {
+        onSuccess: (result) => {
+          showSuccessToast(
+            t("contacts.imported", {
+              imported: result.imported,
+              skipped: result.skipped,
+            }),
+          )
+          handleClose(false)
+        },
+      },
+    )
+  }
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      setFile(null)
+      setSelectedGroups([])
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ""
+      }
+    }
+    setIsOpen(open)
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogTrigger asChild>
+        <Button variant="outline">
+          <Upload className="size-4" />
+          {t("contacts.import")}
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("contacts.importVcard")}</DialogTitle>
+          <DialogDescription>{t("contacts.importDesc")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <label className="text-sm font-medium" htmlFor="vcf-file">
+              {t("contacts.selectFile")}
+            </label>
+            <input
+              ref={fileInputRef}
+              id="vcf-file"
+              type="file"
+              accept=".vcf"
+              onChange={handleFileChange}
+              className="text-sm file:mr-4 file:rounded-md file:border-0 file:bg-primary file:px-4 file:py-2 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90 file:cursor-pointer"
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <label className="text-sm font-medium">
+              {t("contacts.importToGroup")}
+            </label>
+            <MultiSelect
+              options={(groups?.data || []).map((group) => ({
+                label: group.name,
+                value: group.id,
+              }))}
+              onValueChange={setSelectedGroups}
+              defaultValue={selectedGroups}
+              placeholder={t("contacts.groups")}
+              maxVisibleBadges={1}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline" disabled={importMutation.isPending}>
+              {t("common.cancel")}
+            </Button>
+          </DialogClose>
+          <LoadingButton
+            onClick={handleImport}
+            loading={importMutation.isPending}
+            disabled={!file}
+          >
+            {t("contacts.import")}
+          </LoadingButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ImportContacts

--- a/frontend/src/components/Contacts/columns.tsx
+++ b/frontend/src/components/Contacts/columns.tsx
@@ -1,0 +1,68 @@
+import type { ColumnDef } from "@tanstack/react-table"
+import type { TFunction } from "i18next"
+
+import { ContactActionsMenu } from "@/components/Contacts/ContactActionsMenu"
+import { Badge } from "@/components/ui/badge"
+import { formatDate } from "@/lib/utils"
+import type { Contact, ContactGroup } from "@/types/collections"
+
+export function getColumns(
+  t: TFunction,
+  groups: ContactGroup[],
+): ColumnDef<Contact>[] {
+  const groupMap = new Map(groups.map((g) => [g.id, g.name]))
+
+  return [
+    {
+      accessorKey: "name",
+      header: t("contacts.name"),
+      cell: ({ row }) => (
+        <span className="font-medium">{row.original.name}</span>
+      ),
+    },
+    {
+      accessorKey: "phone_number",
+      header: t("contacts.phoneNumber"),
+      cell: ({ row }) => (
+        <span className="font-mono text-muted-foreground">
+          {row.original.phone_number}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "groups",
+      header: t("contacts.groups"),
+      cell: ({ row }) => {
+        const contactGroups = row.original.groups || []
+        if (contactGroups.length === 0) return null
+        return (
+          <div className="flex flex-wrap gap-1">
+            {contactGroups.map((groupId) => (
+              <Badge key={groupId} variant="secondary" className="text-xs">
+                {groupMap.get(groupId) || groupId}
+              </Badge>
+            ))}
+          </div>
+        )
+      },
+    },
+    {
+      accessorKey: "created",
+      header: t("common.created"),
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">
+          {formatDate(row.original.created)}
+        </span>
+      ),
+    },
+    {
+      id: "actions",
+      header: () => <span className="sr-only">{t("common.actions")}</span>,
+      cell: ({ row }) => (
+        <div className="flex justify-end">
+          <ContactActionsMenu contact={row.original} />
+        </div>
+      ),
+    },
+  ]
+}

--- a/frontend/src/components/Pending/PendingContacts.tsx
+++ b/frontend/src/components/Pending/PendingContacts.tsx
@@ -1,0 +1,50 @@
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
+const PendingContacts = () => (
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead>Name</TableHead>
+        <TableHead>Phone Number</TableHead>
+        <TableHead>Groups</TableHead>
+        <TableHead>Created</TableHead>
+        <TableHead>
+          <span className="sr-only">Actions</span>
+        </TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {Array.from({ length: 5 }).map((_, index) => (
+        <TableRow key={index}>
+          <TableCell>
+            <Skeleton className="h-4 w-32" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-28" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-5 w-20 rounded-full" />
+          </TableCell>
+          <TableCell>
+            <Skeleton className="h-4 w-36" />
+          </TableCell>
+          <TableCell>
+            <div className="flex justify-end">
+              <Skeleton className="size-8 rounded-md" />
+            </div>
+          </TableCell>
+        </TableRow>
+      ))}
+    </TableBody>
+  </Table>
+)
+
+export default PendingContacts

--- a/frontend/src/components/Plans/BalanceCard.tsx
+++ b/frontend/src/components/Plans/BalanceCard.tsx
@@ -1,5 +1,6 @@
 import { Wallet } from "lucide-react"
 import { useTranslation } from "react-i18next"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import useAppConfig from "@/hooks/useAppConfig"
 import { useBalance } from "@/hooks/useBalance"
@@ -35,12 +36,9 @@ function BalanceCard() {
         <CardContent>
           <TopUpDialog
             trigger={
-              <button
-                type="button"
-                className="w-full rounded-lg border border-dashed border-brand/40 py-2.5 text-sm font-medium text-brand transition-colors hover:bg-brand/5"
-              >
+              <Button variant="outline" className="w-full">
                 {t("plans.addFunds")}
-              </button>
+              </Button>
             }
           />
         </CardContent>

--- a/frontend/src/components/Plans/TopUpPopover.tsx
+++ b/frontend/src/components/Plans/TopUpPopover.tsx
@@ -46,12 +46,9 @@ function TopUpPopover() {
           {hasProviders && (
             <TopUpDialog
               trigger={
-                <button
-                  type="button"
-                  className="w-full rounded-md border border-dashed border-brand/40 py-2 text-xs font-medium text-brand transition-colors hover:bg-brand/5"
-                >
+                <Button variant="outline" size="sm" className="w-full">
                   {t("plans.addFunds")}
-                </button>
+                </Button>
               }
             />
           )}

--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -1,5 +1,6 @@
 import {
   Clock,
+  Contact,
   CreditCard,
   FileText,
   Home,
@@ -29,6 +30,7 @@ const baseItems: Item[] = [
   { icon: FileText, title: "sidebar.templates", path: "/templates" },
   { icon: Clock, title: "sidebar.scheduled", path: "/scheduled" },
   { icon: Smartphone, title: "sidebar.devices", path: "/devices" },
+  { icon: Contact, title: "sidebar.contacts", path: "/contacts" },
   { icon: Webhook, title: "sidebar.webhooks", path: "/webhooks" },
   { icon: Key, title: "sidebar.integrations", path: "/integrations" },
   { icon: CreditCard, title: "sidebar.billing", path: "/billing" },

--- a/frontend/src/components/Sms/SendSMS.tsx
+++ b/frontend/src/components/Sms/SendSMS.tsx
@@ -21,8 +21,11 @@ import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { LoadingButton } from "@/components/ui/loading-button"
 import { TagInput } from "@/components/ui/tag-input"
 import { Textarea } from "@/components/ui/textarea"
+import { useContactGroupList } from "@/hooks/useContactGroupList"
+import { useContactList } from "@/hooks/useContactList"
 import { useDeviceList } from "@/hooks/useDeviceList"
 import { useSendSMS } from "@/hooks/useSMSMutations"
+import type { Contact } from "@/types/collections"
 
 const formSchema = z.object({
   recipients: z
@@ -30,6 +33,7 @@ const formSchema = z.object({
     .min(1, "At least one recipient is required"),
   from: z.array(z.string()).min(1, "Device is required"),
   body: z.string().min(1, "Message body is required"),
+  group_ids: z.array(z.string()).optional(),
 })
 
 type FormData = z.infer<typeof formSchema>
@@ -38,6 +42,8 @@ const SendSMS = () => {
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
   const { data: devices } = useDeviceList()
+  const { data: contactGroups } = useContactGroupList()
+  const { data: contacts } = useContactList()
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),
@@ -46,6 +52,7 @@ const SendSMS = () => {
       recipients: [],
       from: [],
       body: "",
+      group_ids: [],
     },
   })
 
@@ -58,9 +65,20 @@ const SendSMS = () => {
   const sendSMSMutation = useSendSMS()
 
   const onSubmit = (data: FormData) => {
+    // Resolve group contacts and merge with manual recipients
+    let allRecipients = [...data.recipients]
+    if (data.group_ids && data.group_ids.length > 0 && contacts?.data) {
+      const groupContacts = (contacts.data as unknown as Contact[]).filter(
+        (c) =>
+          c.groups?.some((g) => data.group_ids?.includes(g)),
+      )
+      const groupPhones = groupContacts.map((c) => c.phone_number)
+      allRecipients = [...new Set([...allRecipients, ...groupPhones])]
+    }
+
     sendSMSMutation.mutate(
       {
-        recipients: data.recipients,
+        recipients: allRecipients,
         body: data.body,
         device_id: data.from[0],
       },
@@ -88,6 +106,28 @@ const SendSMS = () => {
         </DialogHeader>
 
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 py-4">
+          {/* Send to Group Field */}
+          <Controller
+            name="group_ids"
+            control={form.control}
+            render={({ field }) => (
+              <Field>
+                <FieldLabel htmlFor={field.name}>
+                  {t("contacts.sendToGroup")}
+                </FieldLabel>
+                <MultiSelect
+                  options={(contactGroups?.data || []).map((group) => ({
+                    label: group.name,
+                    value: group.id,
+                  }))}
+                  onValueChange={field.onChange}
+                  defaultValue={field.value || []}
+                  placeholder={t("contacts.groups")}
+                />
+              </Field>
+            )}
+          />
+
           {/* Recipient Field */}
           <Controller
             name="recipients"
@@ -102,6 +142,10 @@ const SendSMS = () => {
                   id={field.name}
                   placeholder={t("sms.recipientPlaceholder")}
                   aria-invalid={fieldState.invalid}
+                  suggestions={((contacts?.data || []) as unknown as Contact[]).map((c) => ({
+                    label: c.name,
+                    value: c.phone_number,
+                  }))}
                 />
                 {fieldState.invalid && (
                   <FieldError errors={[fieldState.error]} />

--- a/frontend/src/components/ui/tag-input.tsx
+++ b/frontend/src/components/ui/tag-input.tsx
@@ -1,87 +1,168 @@
-import * as React from "react";
-import { X } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
+import * as React from "react"
+import { X } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+import { cn } from "@/lib/utils"
 
-export interface TagInputProps extends Omit<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  "value" | "onChange"
-> {
-  value: string[];
-  onChange: (value: string[]) => void;
+export interface TagSuggestion {
+  label: string
+  value: string
+}
+
+export interface TagInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "value" | "onChange"> {
+  value: string[]
+  onChange: (value: string[]) => void
+  suggestions?: TagSuggestion[]
 }
 
 const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
-  ({ className, value, onChange, placeholder, ...props }, ref) => {
-    const [inputValue, setInputValue] = React.useState("");
+  ({ className, value, onChange, placeholder, suggestions, ...props }, ref) => {
+    const [inputValue, setInputValue] = React.useState("")
+    const [showSuggestions, setShowSuggestions] = React.useState(false)
+    const [activeIndex, setActiveIndex] = React.useState(-1)
+    const containerRef = React.useRef<HTMLDivElement>(null)
 
-    const addPendingValue = () => {
-      const trimmedValue = inputValue.trim();
-      if (trimmedValue && !value.includes(trimmedValue)) {
-        onChange([...value, trimmedValue]);
-        setInputValue("");
+    const filtered = React.useMemo(() => {
+      if (!suggestions || inputValue.length < 2) return []
+      const query = inputValue.toLowerCase()
+      return suggestions.filter(
+        (s) =>
+          !value.includes(s.value) &&
+          (s.label.toLowerCase().includes(query) ||
+            s.value.includes(query)),
+      )
+    }, [suggestions, inputValue, value])
+
+    const addTag = (tag: string) => {
+      const trimmed = tag.trim()
+      if (trimmed && !value.includes(trimmed)) {
+        onChange([...value, trimmed])
       }
-    };
+      setInputValue("")
+      setShowSuggestions(false)
+      setActiveIndex(-1)
+    }
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === " " || e.key === "Enter") {
-        e.preventDefault();
-        addPendingValue();
-      } else if (e.key === "Backspace" && !inputValue && value.length > 0) {
-        onChange(value.slice(0, -1));
+      if (filtered.length > 0 && showSuggestions) {
+        if (e.key === "ArrowDown") {
+          e.preventDefault()
+          setActiveIndex((i) => (i + 1) % filtered.length)
+          return
+        }
+        if (e.key === "ArrowUp") {
+          e.preventDefault()
+          setActiveIndex((i) => (i <= 0 ? filtered.length - 1 : i - 1))
+          return
+        }
+        if (e.key === "Enter" && activeIndex >= 0) {
+          e.preventDefault()
+          addTag(filtered[activeIndex].value)
+          return
+        }
+        if (e.key === "Escape") {
+          setShowSuggestions(false)
+          setActiveIndex(-1)
+          return
+        }
       }
-    };
+
+      if (e.key === " " || e.key === "Enter") {
+        e.preventDefault()
+        addTag(inputValue)
+      } else if (e.key === "Backspace" && !inputValue && value.length > 0) {
+        onChange(value.slice(0, -1))
+      }
+    }
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      setInputValue(e.target.value)
+      setShowSuggestions(true)
+      setActiveIndex(-1)
+    }
 
     const handleBlur = () => {
-      addPendingValue();
-    };
+      // Delay to allow suggestion click to fire
+      setTimeout(() => {
+        addTag(inputValue)
+        setShowSuggestions(false)
+      }, 150)
+    }
 
     const removeTag = (tagToRemove: string) => {
-      onChange(value.filter((tag) => tag !== tagToRemove));
-    };
+      onChange(value.filter((tag) => tag !== tagToRemove))
+    }
 
     return (
-      <div
-        className={cn(
-          "flex min-h-10 w-full flex-wrap gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
-          className,
-        )}
-      >
-        {value.map((tag) => (
-          <Badge key={tag} variant="secondary" className="gap-1 px-1">
-            {tag}
-            <button
-              type="button"
-              className="rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  removeTag(tag);
-                }
-              }}
-              onMouseDown={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-              }}
-              onClick={() => removeTag(tag)}
-            >
-              <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
-            </button>
-          </Badge>
-        ))}
-        <input
-          {...props}
-          ref={ref}
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onBlur={handleBlur}
-          placeholder={value.length === 0 ? placeholder : ""}
-          className="flex-1 bg-transparent outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed"
-        />
-      </div>
-    );
-  },
-);
-TagInput.displayName = "TagInput";
+      <div ref={containerRef} className="relative">
+        <div
+          className={cn(
+            "flex min-h-10 w-full flex-wrap gap-2 rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+            className,
+          )}
+        >
+          {value.map((tag) => (
+            <Badge key={tag} variant="secondary" className="gap-1 px-1">
+              {tag}
+              <button
+                type="button"
+                className="rounded-full outline-none ring-offset-background focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    removeTag(tag)
+                  }
+                }}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                }}
+                onClick={() => removeTag(tag)}
+              >
+                <X className="h-3 w-3 text-muted-foreground hover:text-foreground" />
+              </button>
+            </Badge>
+          ))}
+          <input
+            {...props}
+            ref={ref}
+            value={inputValue}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            onFocus={() => inputValue.length >= 2 && setShowSuggestions(true)}
+            placeholder={value.length === 0 ? placeholder : ""}
+            className="flex-1 bg-transparent outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed"
+          />
+        </div>
 
-export { TagInput };
+        {showSuggestions && filtered.length > 0 && (
+          <ul className="absolute z-50 mt-1 max-h-48 w-full overflow-auto rounded-md border bg-popover p-1 shadow-md">
+            {filtered.map((suggestion, i) => (
+              <li
+                key={suggestion.value}
+                onMouseDown={(e) => {
+                  e.preventDefault()
+                  addTag(suggestion.value)
+                }}
+                className={cn(
+                  "flex cursor-pointer items-center justify-between rounded-sm px-2 py-1.5 text-sm",
+                  i === activeIndex
+                    ? "bg-accent text-accent-foreground"
+                    : "hover:bg-accent/50",
+                )}
+              >
+                <span>{suggestion.label}</span>
+                <span className="font-mono text-xs text-muted-foreground">
+                  {suggestion.value}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    )
+  },
+)
+TagInput.displayName = "TagInput"
+
+export { TagInput }

--- a/frontend/src/hooks/useContactGroupList.ts
+++ b/frontend/src/hooks/useContactGroupList.ts
@@ -1,0 +1,24 @@
+import { queryOptions, useQuery, useSuspenseQuery } from "@tanstack/react-query"
+import pb from "@/lib/pocketbase"
+import { useRealtimeQuery } from "./useRealtimeQuery"
+
+export const contactGroupListQueryOptions = queryOptions({
+  queryKey: ["contact-groups"],
+  queryFn: async () => {
+    const result = await pb.collection("contact_groups").getList(1, 100, {
+      sort: "name",
+    })
+    return { data: result.items, count: result.totalItems }
+  },
+  staleTime: 60_000,
+})
+
+export function useContactGroupList() {
+  useRealtimeQuery("contact_groups", [["contact-groups"]])
+  return useQuery(contactGroupListQueryOptions)
+}
+
+export function useContactGroupListSuspense() {
+  useRealtimeQuery("contact_groups", [["contact-groups"]])
+  return useSuspenseQuery(contactGroupListQueryOptions)
+}

--- a/frontend/src/hooks/useContactGroupMutations.ts
+++ b/frontend/src/hooks/useContactGroupMutations.ts
@@ -1,0 +1,75 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import pb from "@/lib/pocketbase"
+import useCustomToast from "./useCustomToast"
+
+interface ContactGroupCreate {
+  name: string
+}
+
+interface ContactGroupUpdate {
+  name?: string
+}
+
+export function useCreateContactGroup() {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (data: ContactGroupCreate) => {
+      return await pb.collection("contact_groups").create({
+        ...data,
+        user: pb.authStore.record?.id,
+      })
+    },
+    onSuccess: () => {
+      showSuccessToast("Group created successfully")
+    },
+    onError: (error: Error) => {
+      showErrorToast(error.message || "Failed to create group")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["contact-groups"] })
+    },
+  })
+}
+
+export function useUpdateContactGroup(groupId: string) {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (data: ContactGroupUpdate) => {
+      return await pb.collection("contact_groups").update(groupId, data)
+    },
+    onSuccess: () => {
+      showSuccessToast("Group updated successfully")
+    },
+    onError: (error: Error) => {
+      showErrorToast(error.message || "Failed to update group")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["contact-groups"] })
+    },
+  })
+}
+
+export function useDeleteContactGroup() {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (groupId: string) => {
+      return await pb.collection("contact_groups").delete(groupId)
+    },
+    onSuccess: () => {
+      showSuccessToast("Group deleted successfully")
+    },
+    onError: (error: Error) => {
+      showErrorToast(error.message || "Failed to delete group")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["contact-groups"] })
+    },
+  })
+}

--- a/frontend/src/hooks/useContactImport.ts
+++ b/frontend/src/hooks/useContactImport.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import pb from "@/lib/pocketbase"
+import useCustomToast from "./useCustomToast"
+
+interface ImportResult {
+  imported: number
+  skipped: number
+}
+
+export function useContactImport() {
+  const queryClient = useQueryClient()
+  const { showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (data: {
+      file: File
+      groupId?: string
+    }): Promise<ImportResult> => {
+      const formData = new FormData()
+      formData.append("file", data.file)
+      if (data.groupId) formData.append("group_id", data.groupId)
+      return await pb.send("/api/contacts/import", {
+        method: "POST",
+        body: formData,
+      })
+    },
+    onError: (error: Error) => {
+      showErrorToast(error.message || "Failed to import contacts")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["contacts"] })
+    },
+  })
+}

--- a/frontend/src/hooks/useContactList.ts
+++ b/frontend/src/hooks/useContactList.ts
@@ -1,0 +1,25 @@
+import { queryOptions, useQuery, useSuspenseQuery } from "@tanstack/react-query"
+import pb from "@/lib/pocketbase"
+import { useRealtimeQuery } from "./useRealtimeQuery"
+
+export const contactListQueryOptions = queryOptions({
+  queryKey: ["contacts"],
+  queryFn: async () => {
+    const result = await pb.collection("contacts").getList(1, 100, {
+      sort: "-created",
+      expand: "groups",
+    })
+    return { data: result.items, count: result.totalItems }
+  },
+  staleTime: 60_000,
+})
+
+export function useContactList() {
+  useRealtimeQuery("contacts", [["contacts"]])
+  return useQuery(contactListQueryOptions)
+}
+
+export function useContactListSuspense() {
+  useRealtimeQuery("contacts", [["contacts"]])
+  return useSuspenseQuery(contactListQueryOptions)
+}

--- a/frontend/src/hooks/useContactMutations.ts
+++ b/frontend/src/hooks/useContactMutations.ts
@@ -1,0 +1,81 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import pb from "@/lib/pocketbase"
+import useCustomToast from "./useCustomToast"
+
+interface ContactCreate {
+  name: string
+  phone_number: string
+  groups?: string[]
+  notes?: string
+}
+
+interface ContactUpdate {
+  name?: string
+  phone_number?: string
+  groups?: string[]
+  notes?: string
+}
+
+export function useCreateContact() {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (data: ContactCreate) => {
+      return await pb.collection("contacts").create({
+        ...data,
+        user: pb.authStore.record?.id,
+      })
+    },
+    onSuccess: () => {
+      showSuccessToast("Contact created successfully")
+    },
+    onError: (error: Error) => {
+      showErrorToast(error.message || "Failed to create contact")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["contacts"] })
+    },
+  })
+}
+
+export function useUpdateContact(contactId: string) {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (data: ContactUpdate) => {
+      return await pb.collection("contacts").update(contactId, data)
+    },
+    onSuccess: () => {
+      showSuccessToast("Contact updated successfully")
+    },
+    onError: (error: Error) => {
+      showErrorToast(error.message || "Failed to update contact")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["contacts"] })
+    },
+  })
+}
+
+export function useDeleteContact() {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (contactId: string) => {
+      return await pb.collection("contacts").delete(contactId)
+    },
+    onSuccess: () => {
+      showSuccessToast("Contact deleted successfully")
+    },
+    onError: (error: Error) => {
+      showErrorToast(error.message || "Failed to delete contact")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["contacts"] })
+    },
+  })
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -207,7 +207,8 @@
     "admin": "Admin",
     "settings": "Settings",
     "userSettings": "User Settings",
-    "logOut": "Log Out"
+    "logOut": "Log Out",
+    "contacts": "Contacts"
   },
   "appearance": {
     "appearance": "Appearance",
@@ -603,6 +604,29 @@
     "viewDocsDesc": "Guides, setup instructions, and platform overview",
     "viewApiRef": "API Reference",
     "viewApiRefDesc": "Endpoints, parameters, and code examples for sending SMS"
+  },
+  "contacts": {
+    "title": "Contacts",
+    "description": "Manage your contact list and groups",
+    "addContact": "Add Contact",
+    "editContact": "Edit Contact",
+    "deleteContact": "Delete Contact",
+    "deleteContactDesc": "This will permanently delete this contact.",
+    "noContacts": "No contacts yet",
+    "noContactsDesc": "Add contacts manually or import from a vCard file.",
+    "name": "Name",
+    "phoneNumber": "Phone Number",
+    "notes": "Notes",
+    "groups": "Groups",
+    "addGroup": "Add Group",
+    "groupName": "Group name",
+    "import": "Import",
+    "importVcard": "Import vCard",
+    "importDesc": "Import contacts from a .vcf file exported from your phone or email client.",
+    "selectFile": "Select .vcf file",
+    "importToGroup": "Add to group (optional)",
+    "imported": "Imported {{imported}} contacts, {{skipped}} skipped",
+    "sendToGroup": "Send to group"
   },
   "errors": {
     "notFound": "404",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -207,7 +207,8 @@
     "admin": "Admin",
     "settings": "Configuración",
     "userSettings": "Configuración de usuario",
-    "logOut": "Cerrar sesión"
+    "logOut": "Cerrar sesión",
+    "contacts": "Contactos"
   },
   "appearance": {
     "appearance": "Apariencia",
@@ -603,6 +604,29 @@
     "viewDocsDesc": "Guías, instrucciones de configuración y descripción de la plataforma",
     "viewApiRef": "Referencia de la API",
     "viewApiRefDesc": "Endpoints, parámetros y ejemplos de código para enviar SMS"
+  },
+  "contacts": {
+    "title": "Contactos",
+    "description": "Administra tu lista de contactos y grupos",
+    "addContact": "Agregar contacto",
+    "editContact": "Editar contacto",
+    "deleteContact": "Eliminar contacto",
+    "deleteContactDesc": "Esto eliminará permanentemente este contacto.",
+    "noContacts": "Sin contactos",
+    "noContactsDesc": "Agrega contactos manualmente o importa desde un archivo vCard.",
+    "name": "Nombre",
+    "phoneNumber": "Número de teléfono",
+    "notes": "Notas",
+    "groups": "Grupos",
+    "addGroup": "Agregar grupo",
+    "groupName": "Nombre del grupo",
+    "import": "Importar",
+    "importVcard": "Importar vCard",
+    "importDesc": "Importa contactos desde un archivo .vcf exportado de tu teléfono o cliente de correo.",
+    "selectFile": "Seleccionar archivo .vcf",
+    "importToGroup": "Agregar a grupo (opcional)",
+    "imported": "{{imported}} contactos importados, {{skipped}} omitidos",
+    "sendToGroup": "Enviar a grupo"
   },
   "errors": {
     "notFound": "404",

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as LayoutSettingsRouteImport } from './routes/_layout/settings'
 import { Route as LayoutScheduledRouteImport } from './routes/_layout/scheduled'
 import { Route as LayoutIntegrationsRouteImport } from './routes/_layout/integrations'
 import { Route as LayoutDevicesRouteImport } from './routes/_layout/devices'
+import { Route as LayoutContactsRouteImport } from './routes/_layout/contacts'
 import { Route as LayoutBillingRouteImport } from './routes/_layout/billing'
 import { Route as LayoutAdminRouteImport } from './routes/_layout/admin'
 
@@ -131,6 +132,11 @@ const LayoutDevicesRoute = LayoutDevicesRouteImport.update({
   path: '/devices',
   getParentRoute: () => LayoutRoute,
 } as any)
+const LayoutContactsRoute = LayoutContactsRouteImport.update({
+  id: '/contacts',
+  path: '/contacts',
+  getParentRoute: () => LayoutRoute,
+} as any)
 const LayoutBillingRoute = LayoutBillingRouteImport.update({
   id: '/billing',
   path: '/billing',
@@ -153,6 +159,7 @@ export interface FileRoutesByFullPath {
   '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof LayoutAdminRoute
   '/billing': typeof LayoutBillingRoute
+  '/contacts': typeof LayoutContactsRoute
   '/devices': typeof LayoutDevicesRoute
   '/integrations': typeof LayoutIntegrationsRoute
   '/scheduled': typeof LayoutScheduledRoute
@@ -176,6 +183,7 @@ export interface FileRoutesByTo {
   '/verify-email': typeof VerifyEmailRoute
   '/admin': typeof LayoutAdminRoute
   '/billing': typeof LayoutBillingRoute
+  '/contacts': typeof LayoutContactsRoute
   '/devices': typeof LayoutDevicesRoute
   '/integrations': typeof LayoutIntegrationsRoute
   '/scheduled': typeof LayoutScheduledRoute
@@ -201,6 +209,7 @@ export interface FileRoutesById {
   '/verify-email': typeof VerifyEmailRoute
   '/_layout/admin': typeof LayoutAdminRoute
   '/_layout/billing': typeof LayoutBillingRoute
+  '/_layout/contacts': typeof LayoutContactsRoute
   '/_layout/devices': typeof LayoutDevicesRoute
   '/_layout/integrations': typeof LayoutIntegrationsRoute
   '/_layout/scheduled': typeof LayoutScheduledRoute
@@ -226,6 +235,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/admin'
     | '/billing'
+    | '/contacts'
     | '/devices'
     | '/integrations'
     | '/scheduled'
@@ -249,6 +259,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/admin'
     | '/billing'
+    | '/contacts'
     | '/devices'
     | '/integrations'
     | '/scheduled'
@@ -273,6 +284,7 @@ export interface FileRouteTypes {
     | '/verify-email'
     | '/_layout/admin'
     | '/_layout/billing'
+    | '/_layout/contacts'
     | '/_layout/devices'
     | '/_layout/integrations'
     | '/_layout/scheduled'
@@ -443,6 +455,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutDevicesRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/contacts': {
+      id: '/_layout/contacts'
+      path: '/contacts'
+      fullPath: '/contacts'
+      preLoaderRoute: typeof LayoutContactsRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/billing': {
       id: '/_layout/billing'
       path: '/billing'
@@ -463,6 +482,7 @@ declare module '@tanstack/react-router' {
 interface LayoutRouteChildren {
   LayoutAdminRoute: typeof LayoutAdminRoute
   LayoutBillingRoute: typeof LayoutBillingRoute
+  LayoutContactsRoute: typeof LayoutContactsRoute
   LayoutDevicesRoute: typeof LayoutDevicesRoute
   LayoutIntegrationsRoute: typeof LayoutIntegrationsRoute
   LayoutScheduledRoute: typeof LayoutScheduledRoute
@@ -476,6 +496,7 @@ interface LayoutRouteChildren {
 const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutAdminRoute: LayoutAdminRoute,
   LayoutBillingRoute: LayoutBillingRoute,
+  LayoutContactsRoute: LayoutContactsRoute,
   LayoutDevicesRoute: LayoutDevicesRoute,
   LayoutIntegrationsRoute: LayoutIntegrationsRoute,
   LayoutScheduledRoute: LayoutScheduledRoute,

--- a/frontend/src/routes/_layout.tsx
+++ b/frontend/src/routes/_layout.tsx
@@ -28,6 +28,7 @@ const PAGE_TITLE_KEYS: Record<string, string> = {
   "/templates": "sidebar.templates",
   "/scheduled": "sidebar.scheduled",
   "/devices": "sidebar.devices",
+  "/contacts": "contacts.title",
   "/webhooks": "sidebar.webhooks",
   "/integrations": "sidebar.integrations",
   "/billing": "sidebar.billing",
@@ -94,9 +95,7 @@ function Layout() {
   }
 
   return (
-    <>
-      <AnnouncementBanner />
-      <SidebarProvider>
+    <SidebarProvider>
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:outline-none"
@@ -105,6 +104,7 @@ function Layout() {
         </a>
         <AppSidebar />
         <SidebarInset>
+          <AnnouncementBanner />
           <header className="sticky top-0 z-10 flex h-16 shrink-0 items-center gap-2 border-b bg-background px-4">
             <SidebarTrigger className="-ml-1 text-muted-foreground" />
             {pageTitle && (
@@ -133,7 +133,6 @@ function Layout() {
           <Footer />
         </SidebarInset>
       </SidebarProvider>
-    </>
   )
 }
 

--- a/frontend/src/routes/_layout/contacts.tsx
+++ b/frontend/src/routes/_layout/contacts.tsx
@@ -1,0 +1,98 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Plus, Users } from "lucide-react"
+import { Suspense, useMemo } from "react"
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { DataTable } from "@/components/Common/DataTable"
+import AddContact from "@/components/Contacts/AddContact"
+import AddGroup from "@/components/Contacts/AddGroup"
+import { getColumns } from "@/components/Contacts/columns"
+import ImportContacts from "@/components/Contacts/ImportContacts"
+import PendingContacts from "@/components/Pending/PendingContacts"
+import { Button } from "@/components/ui/button"
+import useAppConfig from "@/hooks/useAppConfig"
+import { useContactGroupList } from "@/hooks/useContactGroupList"
+import { useContactListSuspense } from "@/hooks/useContactList"
+import type { Contact, ContactGroup } from "@/types/collections"
+
+export const Route = createFileRoute("/_layout/contacts")({
+  component: Contacts,
+})
+
+function ContactsEmptyState({ onAddContact }: { onAddContact: () => void }) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col items-center justify-center text-center py-12">
+      <div className="rounded-full bg-muted p-4 mb-4">
+        <Users className="h-8 w-8 text-muted-foreground" />
+      </div>
+      <h2 className="text-lg font-semibold">{t("contacts.noContacts")}</h2>
+      <p className="text-muted-foreground">{t("contacts.noContactsDesc")}</p>
+      <Button className="my-4" onClick={onAddContact}>
+        <Plus />
+        {t("contacts.addContact")}
+      </Button>
+    </div>
+  )
+}
+
+function ContactsTableContent({
+  onAddContact,
+}: { onAddContact: () => void }) {
+  const { t } = useTranslation()
+  const { data: contacts } = useContactListSuspense()
+  const { data: groups } = useContactGroupList()
+  const columns = useMemo(
+    () =>
+      getColumns(
+        t,
+        ((groups?.data ?? []) as unknown as ContactGroup[]),
+      ),
+    [t, groups],
+  )
+
+  if (!contacts?.data || contacts.data.length === 0) {
+    return <ContactsEmptyState onAddContact={onAddContact} />
+  }
+
+  return (
+    <DataTable
+      columns={columns}
+      data={(contacts?.data ?? []) as unknown as Contact[]}
+      caption={t("contacts.title")}
+    />
+  )
+}
+
+function ContactsTable({ onAddContact }: { onAddContact: () => void }) {
+  return (
+    <Suspense fallback={<PendingContacts />}>
+      <ContactsTableContent onAddContact={onAddContact} />
+    </Suspense>
+  )
+}
+
+function Contacts() {
+  const { t } = useTranslation()
+  const { config } = useAppConfig()
+  const [addContactOpen, setAddContactOpen] = useState(false)
+
+  return (
+    <div className="flex flex-col gap-6">
+      <title>{`${t("contacts.title")} - ${config.appName}`}</title>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl">{t("contacts.title")}</h1>
+          <p className="text-muted-foreground">{t("contacts.description")}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <ImportContacts />
+          <AddGroup />
+          <AddContact open={addContactOpen} onOpenChange={setAddContactOpen} />
+        </div>
+      </div>
+      <ContactsTable onAddContact={() => setAddContactOpen(true)} />
+    </div>
+  )
+}

--- a/frontend/src/types/collections.ts
+++ b/frontend/src/types/collections.ts
@@ -211,6 +211,21 @@ export interface UserBalance {
   wallet_id: string
 }
 
+// ── Contacts ────────────────────────────────────────────────────────
+
+export interface Contact extends BaseRecord {
+  name: string
+  phone_number: string
+  groups: string[]
+  notes: string
+  user: string
+}
+
+export interface ContactGroup extends BaseRecord {
+  name: string
+  user: string
+}
+
 // ── System Config ────────────────────────────────────────────────────
 
 export interface SystemConfig extends BaseRecord {


### PR DESCRIPTION
## Summary
- New `contacts` and `contact_groups` collections with full CRUD
- vCard (.vcf) import endpoint for bulk contact upload
- Send SMS handler accepts `group_id` to resolve recipients from groups
- Contacts page with table, add/edit/delete dialogs, group management
- TagInput with autocomplete from contacts in SMS send form
- Responsive announcement banner placement fix
- Support email and "Hecho con amor desde Cuba" in dashboard footer
- Standard Button components for Add Funds

## Test plan
- [ ] Create contacts manually and via vCard import
- [ ] Create groups and assign contacts
- [ ] Send SMS to a group
- [ ] Type contact name in SMS recipients → autocomplete suggests
- [ ] Banner displays correctly without overlapping sidebar