### PR TITLE
Add SMS template interpolation with per-recipient variables

### DIFF
--- a/.github/tickets/roadmap.md
+++ b/.github/tickets/roadmap.md
@@ -1,0 +1,43 @@
+# Vendel Roadmap
+
+## 1. Contact Lists / Groups
+Import and manage contact lists with groups. Enable bulk SMS to groups instead of typing numbers manually.
+
+- [ ] `contacts` collection (name, phone, tags/groups, user)
+- [ ] `contact_groups` collection (name, user)
+- [ ] Import from CSV
+- [ ] Group selector in SMS send flow
+- [ ] API endpoint for CRUD
+
+## 2. SMS Retry with Device Failover
+When a device fails to send, automatically re-assign the message to another available device instead of marking it as `failed`.
+
+- [ ] Retry logic in `ProcessSMSAck` on failure
+- [ ] Max retry count (configurable, default 2)
+- [ ] Device cooldown after consecutive failures
+- [ ] Failover only to devices with recent heartbeat
+
+## 3. MMS / Image Support
+Send images and media alongside SMS, depending on device capabilities.
+
+- [ ] Research Android SMS/MMS API limitations
+- [ ] `media` file field on `sms_messages`
+- [ ] FCM payload with media URL
+- [ ] Android app MMS sending support
+- [ ] Modem agent: evaluate MMS AT commands (device-dependent)
+
+## 4. SMS Templates with Variables
+Reusable message templates with variable substitution (`{{name}}`, `{{code}}`).
+
+- [ ] Templates UI (create, edit, preview)
+- [ ] Variable interpolation at send time
+- [ ] Template selector in SMS compose
+- [ ] API support: `template_id` + `variables` in send request
+
+## 5. Scheduled SMS with Recurrence
+Extend scheduled SMS to support recurring sends via cron expressions with full UI support.
+
+- [ ] Frontend cron builder (visual, not raw expression)
+- [ ] Recurrence preview (next 5 runs)
+- [ ] Pause/resume scheduled SMS
+- [ ] Integration with contact groups (scheduled broadcast)

--- a/backend/handlers/sms.go
+++ b/backend/handlers/sms.go
@@ -1,10 +1,11 @@
 package handlers
 
 import (
-	"vendel/middleware"
-	"vendel/services"
+	"fmt"
 	"net/http"
 	"regexp"
+	"vendel/middleware"
+	"vendel/services"
 
 	"github.com/pocketbase/dbx"
 	"github.com/pocketbase/pocketbase/apis"
@@ -15,195 +16,285 @@ var e164Regex = regexp.MustCompile(`^\+[1-9]\d{1,14}$`)
 
 // RegisterSMSRoutes registers custom SMS API routes.
 func RegisterSMSRoutes(se *core.ServeEvent) {
-	// POST /api/sms/send — Send SMS (auth: JWT or API key)
-	se.Router.POST("/api/sms/send", func(e *core.RequestEvent) error {
-		userId, err := middleware.ResolveAuthOrAPIKey(e)
-		if err != nil {
-			return apis.NewUnauthorizedError("Authentication required", nil)
-		}
+	se.Router.POST("/api/sms/send", handleSendSMS)
+	se.Router.POST("/api/sms/send-template", handleSendSMSTemplate)
+	se.Router.POST("/api/sms/report", handleSMSReport)
+	se.Router.POST("/api/sms/incoming", handleIncomingSMS)
+	se.Router.GET("/api/sms/pending", handlePendingMessages)
+	se.Router.POST("/api/sms/fcm-token", handleFCMToken)
+}
 
-		var body struct {
-			Recipients []string `json:"recipients"`
-			Body       string   `json:"body"`
-			DeviceID   string   `json:"device_id"`
-			GroupID    string   `json:"group_id"`
-		}
-		if err := e.BindBody(&body); err != nil {
-			return apis.NewBadRequestError("Invalid request body", nil)
-		}
+// handleSendSMS sends an SMS with a direct body (auth: JWT or API key).
+func handleSendSMS(e *core.RequestEvent) error {
+	userId, err := middleware.ResolveAuthOrAPIKey(e)
+	if err != nil {
+		return apis.NewUnauthorizedError("Authentication required", nil)
+	}
 
-		// Resolve group contacts into recipients
-		if body.GroupID != "" {
-			groupContacts, _ := e.App.FindRecordsByFilter(
-				"contacts",
-				"user = {:userId} && groups.id ?= {:groupId}",
-				"", 0, 0,
-				dbx.Params{"userId": userId, "groupId": body.GroupID},
-			)
-			seen := make(map[string]bool)
-			for _, r := range body.Recipients {
-				seen[r] = true
+	var body struct {
+		Recipients []string `json:"recipients"`
+		Body       string   `json:"body"`
+		DeviceID   string   `json:"device_id"`
+		GroupID    string   `json:"group_id"`
+	}
+	if err := e.BindBody(&body); err != nil {
+		return apis.NewBadRequestError("Invalid request body", nil)
+	}
+
+	recipients, err := resolveRecipients(e.App, userId, body.Recipients, body.GroupID)
+	if err != nil {
+		return apis.NewBadRequestError(err.Error(), nil)
+	}
+
+	if body.Body == "" {
+		return apis.NewBadRequestError("Message body required", nil)
+	}
+	body.Body = services.StripInvisibleUnicode(body.Body)
+	if len(body.Body) > services.MaxMessageBodyLength {
+		return apis.NewBadRequestError(
+			fmt.Sprintf("Message body exceeds %d character limit", services.MaxMessageBodyLength), nil)
+	}
+
+	messages, err := services.SendSMS(e.App, userId, recipients, body.Body, body.DeviceID, nil)
+	if err != nil {
+		return handleServiceError(e, err)
+	}
+
+	return e.JSON(http.StatusOK, buildSendResponse(messages, len(recipients)))
+}
+
+// handleSendSMSTemplate sends an SMS using a saved template (auth: JWT or API key).
+func handleSendSMSTemplate(e *core.RequestEvent) error {
+	userId, err := middleware.ResolveAuthOrAPIKey(e)
+	if err != nil {
+		return apis.NewUnauthorizedError("Authentication required", nil)
+	}
+
+	var body struct {
+		Recipients []string          `json:"recipients"`
+		TemplateID string            `json:"template_id"`
+		Variables  map[string]string `json:"variables"`
+		DeviceID   string            `json:"device_id"`
+		GroupID    string            `json:"group_id"`
+	}
+	if err := e.BindBody(&body); err != nil {
+		return apis.NewBadRequestError("Invalid request body", nil)
+	}
+
+	recipients, err := resolveRecipients(e.App, userId, body.Recipients, body.GroupID)
+	if err != nil {
+		return apis.NewBadRequestError(err.Error(), nil)
+	}
+
+	tmpl, err := resolveTemplate(e.App, userId, body.TemplateID, body.Variables)
+	if err != nil {
+		return apis.NewBadRequestError(err.Error(), nil)
+	}
+
+	messages, err := services.SendSMS(e.App, userId, recipients, "", body.DeviceID, tmpl)
+	if err != nil {
+		return handleServiceError(e, err)
+	}
+
+	return e.JSON(http.StatusOK, buildSendResponse(messages, len(recipients)))
+}
+
+// resolveTemplate validates ownership and builds TemplateOptions from a template ID.
+func resolveTemplate(app core.App, userId, templateId string, variables map[string]string) (*services.TemplateOptions, error) {
+	if templateId == "" {
+		return nil, fmt.Errorf("template_id required")
+	}
+
+	record, err := app.FindRecordById("sms_templates", templateId)
+	if err != nil {
+		return nil, fmt.Errorf("template not found")
+	}
+	if record.GetString("user") != userId {
+		return nil, fmt.Errorf("template does not belong to user")
+	}
+
+	templateBody := services.GetRecordBody(record)
+
+	vars := services.ExtractVariables(templateBody)
+	_, custom := services.ClassifyVariables(vars)
+	for _, v := range custom {
+		if _, ok := variables[v]; !ok {
+			return nil, fmt.Errorf("missing variable: %s", v)
+		}
+	}
+
+	return &services.TemplateOptions{
+		TemplateBody: templateBody,
+		Variables:    variables,
+	}, nil
+}
+
+// handleSMSReport processes a device ACK callback (auth: device API key).
+func handleSMSReport(e *core.RequestEvent) error {
+	device, err := middleware.AuthenticateDevice(e)
+	if err != nil {
+		return apis.NewUnauthorizedError("Invalid API key", nil)
+	}
+
+	var body struct {
+		MessageID    string `json:"message_id"`
+		Status       string `json:"status"`
+		ErrorMessage string `json:"error_message"`
+	}
+	if err := e.BindBody(&body); err != nil {
+		return apis.NewBadRequestError("Invalid request body", nil)
+	}
+
+	validStatuses := map[string]bool{"sent": true, "delivered": true, "failed": true}
+	if !validStatuses[body.Status] {
+		return apis.NewBadRequestError("Invalid status: must be sent, delivered, or failed", nil)
+	}
+
+	if err := services.ProcessSMSAck(e.App, device.Id, body.MessageID, body.Status, body.ErrorMessage); err != nil {
+		return apis.NewNotFoundError(err.Error(), nil)
+	}
+
+	return e.JSON(http.StatusOK, map[string]any{
+		"success":    true,
+		"message_id": body.MessageID,
+		"status":     body.Status,
+	})
+}
+
+// handleIncomingSMS processes an incoming SMS from a device (auth: device API key).
+func handleIncomingSMS(e *core.RequestEvent) error {
+	device, err := middleware.AuthenticateDevice(e)
+	if err != nil {
+		return apis.NewUnauthorizedError("Invalid API key", nil)
+	}
+
+	var body struct {
+		FromNumber string `json:"from_number"`
+		Body       string `json:"body"`
+		Timestamp  string `json:"timestamp"`
+	}
+	if err := e.BindBody(&body); err != nil {
+		return apis.NewBadRequestError("Invalid request body", nil)
+	}
+
+	userId := device.GetString("user")
+	message, err := services.HandleIncomingSMS(e.App, userId, device.Id, body.FromNumber, body.Body, body.Timestamp)
+	if err != nil {
+		return apis.NewApiError(http.StatusInternalServerError, err.Error(), nil)
+	}
+
+	return e.JSON(http.StatusOK, map[string]any{
+		"success":    true,
+		"message_id": message.Id,
+	})
+}
+
+// handlePendingMessages returns pending messages for a device (auth: device API key).
+func handlePendingMessages(e *core.RequestEvent) error {
+	device, err := middleware.AuthenticateDevice(e)
+	if err != nil {
+		return apis.NewUnauthorizedError("Invalid API key", nil)
+	}
+
+	claimed, err := services.ClaimPendingMessages(e.App, device.Id)
+	if err != nil {
+		return apis.NewApiError(http.StatusInternalServerError, "Failed to claim messages", nil)
+	}
+
+	type pendingMsg struct {
+		MessageID string `json:"message_id"`
+		Recipient string `json:"recipient"`
+		Body      string `json:"body"`
+	}
+	msgs := make([]pendingMsg, 0, len(claimed))
+	for _, r := range claimed {
+		msgs = append(msgs, pendingMsg{
+			MessageID: r.Id,
+			Recipient: r.GetString("to"),
+			Body:      services.GetRecordBody(r),
+		})
+	}
+
+	return e.JSON(http.StatusOK, map[string]any{
+		"device_id": device.Id,
+		"messages":  msgs,
+	})
+}
+
+// handleFCMToken updates a device's FCM token (auth: device API key).
+func handleFCMToken(e *core.RequestEvent) error {
+	device, err := middleware.AuthenticateDevice(e)
+	if err != nil {
+		return apis.NewUnauthorizedError("Invalid API key", nil)
+	}
+
+	var body struct {
+		FCMToken string `json:"fcm_token"`
+	}
+	if err := e.BindBody(&body); err != nil {
+		return apis.NewBadRequestError("Invalid request body", nil)
+	}
+
+	device.Set("fcm_token", body.FCMToken)
+	if err := e.App.Save(device); err != nil {
+		return apis.NewApiError(http.StatusInternalServerError, "Failed to update token", nil)
+	}
+
+	return e.JSON(http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// resolveRecipients expands group contacts and validates E.164 format.
+func resolveRecipients(app core.App, userId string, recipients []string, groupID string) ([]string, error) {
+	result := make([]string, len(recipients))
+	copy(result, recipients)
+
+	if groupID != "" {
+		groupContacts, _ := app.FindRecordsByFilter(
+			"contacts",
+			"user = {:userId} && groups.id ?= {:groupId}",
+			"", 0, 0,
+			dbx.Params{"userId": userId, "groupId": groupID},
+		)
+		seen := make(map[string]bool)
+		for _, r := range result {
+			seen[r] = true
+		}
+		for _, c := range groupContacts {
+			phone := c.GetString("phone_number")
+			if !seen[phone] {
+				result = append(result, phone)
+				seen[phone] = true
 			}
-			for _, c := range groupContacts {
-				phone := c.GetString("phone_number")
-				if !seen[phone] {
-					body.Recipients = append(body.Recipients, phone)
-					seen[phone] = true
-				}
-			}
 		}
+	}
 
-		if len(body.Recipients) == 0 {
-			return apis.NewBadRequestError("At least one recipient required", nil)
+	if len(result) == 0 {
+		return nil, fmt.Errorf("at least one recipient required")
+	}
+	for _, r := range result {
+		if !e164Regex.MatchString(r) {
+			return nil, fmt.Errorf("invalid phone number: %s. Must be E.164 format (e.g. +1234567890)", r)
 		}
-		for _, r := range body.Recipients {
-			if !e164Regex.MatchString(r) {
-				return apis.NewBadRequestError("Invalid phone number: "+r+". Must be E.164 format (e.g. +1234567890)", nil)
-			}
-		}
-		if body.Body == "" {
-			return apis.NewBadRequestError("Message body required", nil)
-		}
-		if len(body.Body) > services.MaxMessageBodyLength {
-			return apis.NewBadRequestError("Message body exceeds 1600 character limit", nil)
-		}
+	}
+	return result, nil
+}
 
-		messages, err := services.SendSMS(e.App, userId, body.Recipients, body.Body, body.DeviceID)
-		if err != nil {
-			return handleServiceError(e, err)
-		}
+// buildSendResponse creates the standard response for send endpoints.
+func buildSendResponse(messages []*core.Record, recipientCount int) map[string]any {
+	ids := make([]string, len(messages))
+	for i, m := range messages {
+		ids[i] = m.Id
+	}
 
-		// Build response
-		ids := make([]string, len(messages))
-		for i, m := range messages {
-			ids[i] = m.Id
-		}
+	var batchId string
+	if len(messages) > 0 {
+		batchId = messages[0].GetString("batch_id")
+	}
 
-		var batchId string
-		if len(messages) > 0 {
-			batchId = messages[0].GetString("batch_id")
-		}
-
-		return e.JSON(http.StatusOK, map[string]any{
-			"batch_id":         batchId,
-			"message_ids":      ids,
-			"recipients_count": len(body.Recipients),
-			"status":           "accepted",
-		})
-	})
-
-	// POST /api/sms/report — Device ACK callback (auth: device API key)
-	se.Router.POST("/api/sms/report", func(e *core.RequestEvent) error {
-		device, err := middleware.AuthenticateDevice(e)
-		if err != nil {
-			return apis.NewUnauthorizedError("Invalid API key", nil)
-		}
-
-		var body struct {
-			MessageID    string `json:"message_id"`
-			Status       string `json:"status"`
-			ErrorMessage string `json:"error_message"`
-		}
-		if err := e.BindBody(&body); err != nil {
-			return apis.NewBadRequestError("Invalid request body", nil)
-		}
-
-		// Only allow terminal statuses from device reports
-		validStatuses := map[string]bool{"sent": true, "delivered": true, "failed": true}
-		if !validStatuses[body.Status] {
-			return apis.NewBadRequestError("Invalid status: must be sent, delivered, or failed", nil)
-		}
-
-		if err := services.ProcessSMSAck(e.App, device.Id, body.MessageID, body.Status, body.ErrorMessage); err != nil {
-			return apis.NewNotFoundError(err.Error(), nil)
-		}
-
-		return e.JSON(http.StatusOK, map[string]any{
-			"success":    true,
-			"message_id": body.MessageID,
-			"status":     body.Status,
-		})
-	})
-
-	// POST /api/sms/incoming — Incoming SMS from device (auth: device API key)
-	se.Router.POST("/api/sms/incoming", func(e *core.RequestEvent) error {
-		device, err := middleware.AuthenticateDevice(e)
-		if err != nil {
-			return apis.NewUnauthorizedError("Invalid API key", nil)
-		}
-
-		var body struct {
-			FromNumber string `json:"from_number"`
-			Body       string `json:"body"`
-			Timestamp  string `json:"timestamp"`
-		}
-		if err := e.BindBody(&body); err != nil {
-			return apis.NewBadRequestError("Invalid request body", nil)
-		}
-
-		userId := device.GetString("user")
-		message, err := services.HandleIncomingSMS(e.App, userId, device.Id, body.FromNumber, body.Body, body.Timestamp)
-		if err != nil {
-			return apis.NewApiError(http.StatusInternalServerError, err.Error(), nil)
-		}
-
-		return e.JSON(http.StatusOK, map[string]any{
-			"success":    true,
-			"message_id": message.Id,
-		})
-	})
-
-	// GET /api/sms/pending — Pending messages for devices: Android (post-FCM tickle) and modems (startup recovery) (auth: device API key)
-	se.Router.GET("/api/sms/pending", func(e *core.RequestEvent) error {
-		device, err := middleware.AuthenticateDevice(e)
-		if err != nil {
-			return apis.NewUnauthorizedError("Invalid API key", nil)
-		}
-
-		claimed, err := services.ClaimPendingMessages(e.App, device.Id)
-		if err != nil {
-			return apis.NewApiError(http.StatusInternalServerError, "Failed to claim messages", nil)
-		}
-
-		type pendingMsg struct {
-			MessageID string `json:"message_id"`
-			Recipient string `json:"recipient"`
-			Body      string `json:"body"`
-		}
-		msgs := make([]pendingMsg, 0, len(claimed))
-		for _, r := range claimed {
-			msgs = append(msgs, pendingMsg{
-				MessageID: r.Id,
-				Recipient: r.GetString("to"),
-				Body:      services.GetRecordBody(r),
-			})
-		}
-
-		return e.JSON(http.StatusOK, map[string]any{
-			"device_id": device.Id,
-			"messages":  msgs,
-		})
-	})
-
-	// POST /api/sms/fcm-token — Update device FCM token (auth: device API key)
-	se.Router.POST("/api/sms/fcm-token", func(e *core.RequestEvent) error {
-		device, err := middleware.AuthenticateDevice(e)
-		if err != nil {
-			return apis.NewUnauthorizedError("Invalid API key", nil)
-		}
-
-		var body struct {
-			FCMToken string `json:"fcm_token"`
-		}
-		if err := e.BindBody(&body); err != nil {
-			return apis.NewBadRequestError("Invalid request body", nil)
-		}
-
-		device.Set("fcm_token", body.FCMToken)
-		if err := e.App.Save(device); err != nil {
-			return apis.NewApiError(http.StatusInternalServerError, "Failed to update token", nil)
-		}
-
-		return e.JSON(http.StatusOK, map[string]string{"status": "ok"})
-	})
+	return map[string]any{
+		"batch_id":         batchId,
+		"message_ids":      ids,
+		"recipients_count": recipientCount,
+		"status":           "accepted",
+	}
 }

--- a/backend/services/schedule.go
+++ b/backend/services/schedule.go
@@ -47,7 +47,7 @@ func ProcessDueSchedules(app core.App) error {
 		deviceId := record.GetString("device_id")
 
 		// Send the SMS
-		_, err := SendSMS(app, userId, recipients, body, deviceId)
+		_, err := SendSMS(app, userId, recipients, body, deviceId, nil)
 		if err != nil {
 			app.Logger().Warn("scheduled SMS: send failed",
 				slog.String("id", record.Id), slog.Any("error", err))

--- a/backend/services/sms.go
+++ b/backend/services/sms.go
@@ -11,9 +11,15 @@ import (
 	"github.com/pocketbase/pocketbase/tools/types"
 )
 
+// TemplateOptions holds template interpolation data for per-recipient message generation.
+type TemplateOptions struct {
+	TemplateBody string
+	Variables    map[string]string // custom variables (same for all recipients)
+}
+
 // SendSMS orchestrates the entire SMS sending process.
-// Recipients are distributed among devices via round-robin.
-func SendSMS(app core.App, userId string, recipients []string, body string, deviceId string) ([]*core.Record, error) {
+// If tmpl is non-nil, the message body is interpolated per recipient using template variables.
+func SendSMS(app core.App, userId string, recipients []string, body string, deviceId string, tmpl *TemplateOptions) ([]*core.Record, error) {
 	if len(recipients) == 0 {
 		return nil, fmt.Errorf("no recipients provided")
 	}
@@ -27,7 +33,13 @@ func SendSMS(app core.App, userId string, recipients []string, body string, devi
 		return nil, err
 	}
 
-	messages, err := createMessageRecords(app, userId, recipients, body, devices)
+	// Build contact lookup for template interpolation
+	var contactMap map[string]*core.Record
+	if tmpl != nil {
+		contactMap = buildContactMap(app, userId, recipients)
+	}
+
+	messages, err := createMessageRecords(app, userId, recipients, body, devices, tmpl, contactMap)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +56,6 @@ func SendSMS(app core.App, userId string, recipients []string, body string, devi
 }
 
 // resolveDevices returns the target device(s) for sending.
-// If deviceId is specified, validates ownership. Otherwise, returns all user devices.
 func resolveDevices(app core.App, userId, deviceId string) ([]*core.Record, error) {
 	if deviceId != "" {
 		device, err := app.FindRecordById("sms_devices", deviceId)
@@ -70,8 +81,40 @@ func resolveDevices(app core.App, userId, deviceId string) ([]*core.Record, erro
 	return records, nil
 }
 
+// buildContactMap fetches contacts matching the given phone numbers and indexes them by phone.
+func buildContactMap(app core.App, userId string, phones []string) map[string]*core.Record {
+	if len(phones) == 0 {
+		return nil
+	}
+
+	contacts, err := app.FindRecordsByFilter(
+		"contacts",
+		"user = {:userId} && phone_number IN {:phones}",
+		"", 0, 0,
+		dbx.Params{"userId": userId, "phones": phones},
+	)
+	if err != nil || len(contacts) == 0 {
+		return nil
+	}
+
+	m := make(map[string]*core.Record, len(contacts))
+	for _, c := range contacts {
+		m[c.GetString("phone_number")] = c
+	}
+	return m
+}
+
 // createMessageRecords creates sms_messages records, assigning devices via round-robin.
-func createMessageRecords(app core.App, userId string, recipients []string, body string, devices []*core.Record) ([]*core.Record, error) {
+// When tmpl is non-nil, each message body is interpolated per recipient.
+func createMessageRecords(
+	app core.App,
+	userId string,
+	recipients []string,
+	body string,
+	devices []*core.Record,
+	tmpl *TemplateOptions,
+	contactMap map[string]*core.Record,
+) ([]*core.Record, error) {
 	collection, err := app.FindCollectionByNameOrId("sms_messages")
 	if err != nil {
 		return nil, fmt.Errorf("sms_messages collection not found: %w", err)
@@ -84,9 +127,18 @@ func createMessageRecords(app core.App, userId string, recipients []string, body
 
 	messages := make([]*core.Record, 0, len(recipients))
 	for i, recipient := range recipients {
+		// Determine message body for this recipient
+		msgBody := body
+		if tmpl != nil {
+			msgBody = interpolateForRecipient(tmpl, recipient, contactMap)
+			if len(msgBody) > MaxMessageBodyLength {
+				return nil, fmt.Errorf("interpolated message for %s exceeds %d character limit (%d chars)", recipient, MaxMessageBodyLength, len(msgBody))
+			}
+		}
+
 		record := core.NewRecord(collection)
 		record.Set("to", recipient)
-		record.Set("body", body)
+		record.Set("body", msgBody)
 		record.Set("user", userId)
 		record.Set("message_type", "outgoing")
 		record.Set("webhook_sent", false)
@@ -113,8 +165,28 @@ func createMessageRecords(app core.App, userId string, recipients []string, body
 	return messages, nil
 }
 
+// interpolateForRecipient builds the final message body for a single recipient.
+func interpolateForRecipient(tmpl *TemplateOptions, phone string, contactMap map[string]*core.Record) string {
+	// Start with custom variables
+	vars := make(map[string]string, len(tmpl.Variables)+2)
+	for k, v := range tmpl.Variables {
+		vars[k] = v
+	}
+
+	// Add reserved variables from contact if available
+	if contactMap != nil {
+		if contact, ok := contactMap[phone]; ok {
+			vars["name"] = contact.GetString("name")
+			vars["phone"] = contact.GetString("phone_number")
+		}
+	}
+
+	// Interpolate and strip invisible unicode
+	result := InterpolateBody(tmpl.TemplateBody, vars)
+	return StripInvisibleUnicode(result)
+}
+
 // ProcessSMSAck handles device acknowledgment for a sent SMS.
-// The deviceId must match the message's assigned device.
 func ProcessSMSAck(app core.App, deviceId string, messageId string, status string, errorMessage string) error {
 	record, err := app.FindRecordById("sms_messages", messageId)
 	if err != nil {
@@ -151,7 +223,6 @@ func ProcessSMSAck(app core.App, deviceId string, messageId string, status strin
 
 // HandleIncomingSMS processes an incoming SMS from a device and triggers webhooks.
 func HandleIncomingSMS(app core.App, userId string, deviceId string, fromNumber string, body string, timestamp string) (*core.Record, error) {
-	// Deduplicate: check for identical incoming SMS within the last 5 minutes
 	cutoff := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
 	bodyHash, _ := ComputeBodyHash(body)
 	existing, err := app.FindFirstRecordByFilter(

--- a/backend/services/template.go
+++ b/backend/services/template.go
@@ -1,0 +1,82 @@
+package services
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var (
+	// variableRegex matches {{variable_name}} placeholders.
+	variableRegex = regexp.MustCompile(`\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}`)
+
+	// ReservedVariables are auto-resolved from contact data per recipient.
+	ReservedVariables = map[string]bool{
+		"name":  true,
+		"phone": true,
+	}
+)
+
+// ExtractVariables returns unique variable names found in a template body.
+func ExtractVariables(body string) []string {
+	matches := variableRegex.FindAllStringSubmatch(body, -1)
+	seen := make(map[string]bool)
+	var vars []string
+	for _, m := range matches {
+		name := m[1]
+		if !seen[name] {
+			seen[name] = true
+			vars = append(vars, name)
+		}
+	}
+	return vars
+}
+
+// InterpolateBody replaces {{var}} placeholders with values from the map.
+// Single-pass only — the result is never re-processed, preventing injection.
+// Unresolved variables are left as-is (e.g. {{unknown}} stays literal).
+func InterpolateBody(body string, vars map[string]string) string {
+	return variableRegex.ReplaceAllStringFunc(body, func(match string) string {
+		name := match[2 : len(match)-2] // strip {{ and }}
+		if val, ok := vars[name]; ok {
+			return val
+		}
+		return match
+	})
+}
+
+// StripInvisibleUnicode removes invisible and formatting unicode characters
+// that can manipulate perceived message length. Preserves newlines, tabs, and spaces.
+func StripInvisibleUnicode(s string) string {
+	return strings.Map(func(r rune) rune {
+		// Keep printable ASCII and common whitespace
+		if r == '\n' || r == '\r' || r == '\t' {
+			return r
+		}
+		// Remove Unicode format characters (Cf category)
+		// Includes: zero-width space (U+200B), ZWJ/ZWNJ (U+200C/D),
+		// LTR/RTL marks (U+200E/F, U+202A-202E, U+2066-2069),
+		// BOM (U+FEFF), soft hyphen (U+00AD), word joiner (U+2060)
+		if unicode.Is(unicode.Cf, r) {
+			return -1
+		}
+		// Remove control characters (Cc) except the whitespace we kept above
+		if unicode.Is(unicode.Cc, r) {
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// ClassifyVariables splits variable names into reserved (auto-filled from contact)
+// and custom (user-provided at send time).
+func ClassifyVariables(vars []string) (reserved, custom []string) {
+	for _, v := range vars {
+		if ReservedVariables[v] {
+			reserved = append(reserved, v)
+		} else {
+			custom = append(custom, v)
+		}
+	}
+	return
+}

--- a/frontend/src/components/Common/Footer.tsx
+++ b/frontend/src/components/Common/Footer.tsx
@@ -18,20 +18,24 @@ export function Footer() {
     <footer className="border-t py-4 px-6">
       <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
         <div className="flex flex-col items-center gap-1 sm:items-start">
-          <p className="text-muted-foreground text-sm">Vendel - {currentYear}</p>
+          <p className="text-muted-foreground text-sm">
+            Vendel - {currentYear}
+          </p>
           <p className="flex items-center gap-1 text-xs text-muted-foreground">
-            Hecho con <Heart className="size-3 fill-red-500 text-red-500" /> desde Cuba
+            Hecho con <Heart className="size-3 fill-red-500 text-red-500" />{" "}
+            desde Cuba
           </p>
         </div>
         <div className="flex items-center gap-4">
-          {config.supportEmail && config.supportEmail !== "support@example.com" && (
-            <a
-              href={`mailto:${config.supportEmail}`}
-              className="text-muted-foreground hover:text-foreground transition-colors text-sm"
-            >
-              {config.supportEmail}
-            </a>
-          )}
+          {config.supportEmail &&
+            config.supportEmail !== "support@example.com" && (
+              <a
+                href={`mailto:${config.supportEmail}`}
+                className="text-muted-foreground hover:text-foreground transition-colors text-sm"
+              >
+                {config.supportEmail}
+              </a>
+            )}
           {socialLinks.map(({ icon: Icon, href, label }) => (
             <a
               key={label}

--- a/frontend/src/components/Contacts/AddContact.tsx
+++ b/frontend/src/components/Contacts/AddContact.tsx
@@ -125,7 +125,12 @@ const AddContact = ({ open, onOpenChange }: AddContactProps) => {
                       <span className="text-destructive">*</span>
                     </FormLabel>
                     <FormControl>
-                      <Input placeholder="John Doe" type="text" {...field} required />
+                      <Input
+                        placeholder="John Doe"
+                        type="text"
+                        {...field}
+                        required
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/frontend/src/components/Contacts/EditContact.tsx
+++ b/frontend/src/components/Contacts/EditContact.tsx
@@ -94,9 +94,7 @@ const EditContact = ({ contact, onSuccess }: EditContactProps) => {
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <DialogHeader>
               <DialogTitle>{t("contacts.editContact")}</DialogTitle>
-              <DialogDescription>
-                {t("contacts.description")}
-              </DialogDescription>
+              <DialogDescription>{t("contacts.description")}</DialogDescription>
             </DialogHeader>
             <div className="grid gap-4 py-4">
               <FormField
@@ -109,7 +107,12 @@ const EditContact = ({ contact, onSuccess }: EditContactProps) => {
                       <span className="text-destructive">*</span>
                     </FormLabel>
                     <FormControl>
-                      <Input placeholder="John Doe" type="text" {...field} required />
+                      <Input
+                        placeholder="John Doe"
+                        type="text"
+                        {...field}
+                        required
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/frontend/src/components/ScheduledSMS/AddScheduledSMS.tsx
+++ b/frontend/src/components/ScheduledSMS/AddScheduledSMS.tsx
@@ -173,7 +173,9 @@ const AddScheduledSMS = () => {
 
               <div className="space-y-2">
                 <TemplateSelect
-                  onSelect={(body) => form.setValue("body", body)}
+                  onSelect={(tmpl) => {
+                    if (tmpl) form.setValue("body", tmpl.body)
+                  }}
                 />
               </div>
 

--- a/frontend/src/components/ScheduledSMS/EditScheduledSMS.tsx
+++ b/frontend/src/components/ScheduledSMS/EditScheduledSMS.tsx
@@ -185,7 +185,9 @@ const EditScheduledSMS = ({ schedule, onSuccess }: EditScheduledSMSProps) => {
 
               <div className="space-y-2">
                 <TemplateSelect
-                  onSelect={(body) => form.setValue("body", body)}
+                  onSelect={(tmpl) => {
+                    if (tmpl) form.setValue("body", tmpl.body)
+                  }}
                 />
               </div>
 

--- a/frontend/src/components/Sms/SendSMS.tsx
+++ b/frontend/src/components/Sms/SendSMS.tsx
@@ -5,7 +5,10 @@ import { Controller, useForm } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 import { z } from "zod"
 import { MultiSelect } from "@/components/Common/MultiSelect"
-import { TemplateSelect } from "@/components/Templates/TemplateSelect"
+import {
+  type SelectedTemplate,
+  TemplateSelect,
+} from "@/components/Templates/TemplateSelect"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -18,13 +21,14 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
 import { LoadingButton } from "@/components/ui/loading-button"
 import { TagInput } from "@/components/ui/tag-input"
 import { Textarea } from "@/components/ui/textarea"
 import { useContactGroupList } from "@/hooks/useContactGroupList"
 import { useContactList } from "@/hooks/useContactList"
 import { useDeviceList } from "@/hooks/useDeviceList"
-import { useSendSMS } from "@/hooks/useSMSMutations"
+import { useSendSMS, useSendSMSTemplate } from "@/hooks/useSMSMutations"
 import type { Contact } from "@/types/collections"
 
 const formSchema = z.object({
@@ -32,15 +36,20 @@ const formSchema = z.object({
     .array(z.e164().min(1, "Recipient is required"))
     .min(1, "At least one recipient is required"),
   from: z.array(z.string()).min(1, "Device is required"),
-  body: z.string().min(1, "Message body is required"),
+  body: z.string(),
   group_ids: z.array(z.string()).optional(),
 })
 
 type FormData = z.infer<typeof formSchema>
 
+const RESERVED_VAR_REGEX = /\{\{(name|phone)\}\}/
+
 const SendSMS = () => {
   const { t } = useTranslation()
   const [isOpen, setIsOpen] = useState(false)
+  const [selectedTemplate, setSelectedTemplate] =
+    useState<SelectedTemplate | null>(null)
+  const [templateVars, setTemplateVars] = useState<Record<string, string>>({})
   const { data: devices } = useDeviceList()
   const { data: contactGroups } = useContactGroupList()
   const { data: contacts } = useContactList()
@@ -63,36 +72,80 @@ const SendSMS = () => {
   }, [devices, form])
 
   const sendSMSMutation = useSendSMS()
+  const sendTemplateMutation = useSendSMSTemplate()
+  const isSending = sendSMSMutation.isPending || sendTemplateMutation.isPending
 
-  const onSubmit = (data: FormData) => {
-    // Resolve group contacts and merge with manual recipients
-    let allRecipients = [...data.recipients]
+  const resolveAllRecipients = (data: FormData): string[] => {
+    const result = [...data.recipients]
     if (data.group_ids && data.group_ids.length > 0 && contacts?.data) {
       const groupContacts = (contacts.data as unknown as Contact[]).filter(
-        (c) =>
-          c.groups?.some((g) => data.group_ids?.includes(g)),
+        (c) => c.groups?.some((g) => data.group_ids?.includes(g)),
       )
-      const groupPhones = groupContacts.map((c) => c.phone_number)
-      allRecipients = [...new Set([...allRecipients, ...groupPhones])]
+      for (const c of groupContacts) {
+        if (!result.includes(c.phone_number)) result.push(c.phone_number)
+      }
     }
-
-    sendSMSMutation.mutate(
-      {
-        recipients: allRecipients,
-        body: data.body,
-        device_id: data.from[0],
-      },
-      {
-        onSuccess: () => {
-          form.reset()
-          setIsOpen(false)
-        },
-      },
-    )
+    return result
   }
 
+  const onSubmit = (data: FormData) => {
+    if (!selectedTemplate && !data.body) {
+      form.setError("body", { message: "Message body or template required" })
+      return
+    }
+
+    if (selectedTemplate) {
+      const missing = selectedTemplate.customVariables.filter(
+        (v) => !templateVars[v]?.trim(),
+      )
+      if (missing.length > 0) {
+        form.setError("body", {
+          message: `Missing variables: ${missing.join(", ")}`,
+        })
+        return
+      }
+    }
+
+    const allRecipients = resolveAllRecipients(data)
+    const onSuccess = () => {
+      form.reset()
+      setSelectedTemplate(null)
+      setTemplateVars({})
+      setIsOpen(false)
+    }
+
+    if (selectedTemplate) {
+      sendTemplateMutation.mutate(
+        {
+          recipients: allRecipients,
+          template_id: selectedTemplate.id,
+          variables: templateVars,
+          device_id: data.from[0],
+        },
+        { onSuccess },
+      )
+    } else {
+      sendSMSMutation.mutate(
+        { recipients: allRecipients, body: data.body, device_id: data.from[0] },
+        { onSuccess },
+      )
+    }
+  }
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open)
+    if (!open) {
+      setSelectedTemplate(null)
+      setTemplateVars({})
+    }
+  }
+
+  const hasReservedVars = selectedTemplate
+    ? RESERVED_VAR_REGEX.test(selectedTemplate.body)
+    : false
+
   return (
-    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button className="my-4">
           <Plus className="h-4 w-4" />
@@ -142,7 +195,9 @@ const SendSMS = () => {
                   id={field.name}
                   placeholder={t("sms.recipientPlaceholder")}
                   aria-invalid={fieldState.invalid}
-                  suggestions={((contacts?.data || []) as unknown as Contact[]).map((c) => ({
+                  suggestions={(
+                    (contacts?.data || []) as unknown as Contact[]
+                  ).map((c) => ({
                     label: c.name,
                     value: c.phone_number,
                   }))}
@@ -179,42 +234,82 @@ const SendSMS = () => {
           />
 
           {/* Template Select */}
-          <TemplateSelect onSelect={(body) => form.setValue("body", body)} />
+          <TemplateSelect
+            onSelect={(template) => {
+              setSelectedTemplate(template)
+              setTemplateVars({})
+              form.setValue("body", "")
+              form.clearErrors("body")
+            }}
+          />
 
-          {/* Message Body Field */}
-          <Controller
-            name="body"
-            control={form.control}
-            render={({ field, fieldState }) => (
-              <Field data-invalid={fieldState.invalid}>
-                <FieldLabel htmlFor={field.name}>
-                  {t("sms.body")} <span className="text-destructive">*</span>
-                </FieldLabel>
-                <Textarea
-                  {...field}
-                  id={field.name}
-                  placeholder={t("sms.bodyPlaceholder")}
-                  rows={3}
-                  aria-invalid={fieldState.invalid}
-                />
-                {fieldState.invalid && (
-                  <FieldError errors={[fieldState.error]} />
+          {selectedTemplate ? (
+            <>
+              {/* Template Preview */}
+              <Field>
+                <FieldLabel>{t("templates.templatePreview")}</FieldLabel>
+                <div className="rounded-md border bg-muted/50 p-3 text-sm whitespace-pre-wrap">
+                  {selectedTemplate.body}
+                </div>
+                {hasReservedVars && (
+                  <p className="text-muted-foreground text-xs mt-1">
+                    {t("templates.autoFilledHint")}
+                  </p>
                 )}
               </Field>
-            )}
-          />
+
+              {/* Custom Variable Inputs */}
+              {selectedTemplate.customVariables.map((v) => (
+                <Field key={v}>
+                  <FieldLabel>
+                    {v} <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <Input
+                    value={templateVars[v] || ""}
+                    onChange={(e) =>
+                      setTemplateVars((prev) => ({
+                        ...prev,
+                        [v]: e.target.value,
+                      }))
+                    }
+                    placeholder={t("templates.variableLabel", { var: v })}
+                    required
+                  />
+                </Field>
+              ))}
+            </>
+          ) : (
+            /* Message Body Field */
+            <Controller
+              name="body"
+              control={form.control}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor={field.name}>
+                    {t("sms.body")} <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <Textarea
+                    {...field}
+                    id={field.name}
+                    placeholder={t("sms.bodyPlaceholder")}
+                    rows={3}
+                    aria-invalid={fieldState.invalid}
+                  />
+                  {fieldState.invalid && (
+                    <FieldError errors={[fieldState.error]} />
+                  )}
+                </Field>
+              )}
+            />
+          )}
 
           <DialogFooter>
             <DialogClose asChild>
-              <Button
-                variant="outline"
-                type="button"
-                disabled={sendSMSMutation.isPending}
-              >
+              <Button variant="outline" type="button" disabled={isSending}>
                 {t("common.cancel")}
               </Button>
             </DialogClose>
-            <LoadingButton type="submit" loading={sendSMSMutation.isPending}>
+            <LoadingButton type="submit" loading={isSending}>
               {t("common.send")}
             </LoadingButton>
           </DialogFooter>

--- a/frontend/src/components/Templates/TemplateSelect.tsx
+++ b/frontend/src/components/Templates/TemplateSelect.tsx
@@ -9,8 +9,30 @@ import {
 } from "@/components/ui/select"
 import { useTemplateList } from "@/hooks/useTemplateList"
 
+const VARIABLE_REGEX = /\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}/g
+const RESERVED_VARIABLES = new Set(["name", "phone"])
+
+export interface SelectedTemplate {
+  id: string
+  body: string
+  customVariables: string[]
+}
+
+function extractCustomVariables(body: string): string[] {
+  const seen = new Set<string>()
+  const vars: string[] = []
+  for (const match of body.matchAll(VARIABLE_REGEX)) {
+    const name = match[1]
+    if (!seen.has(name) && !RESERVED_VARIABLES.has(name)) {
+      seen.add(name)
+      vars.push(name)
+    }
+  }
+  return vars
+}
+
 interface TemplateSelectProps {
-  onSelect: (body: string) => void
+  onSelect: (template: SelectedTemplate | null) => void
 }
 
 export const TemplateSelect = ({ onSelect }: TemplateSelectProps) => {
@@ -28,12 +50,17 @@ export const TemplateSelect = ({ onSelect }: TemplateSelectProps) => {
       onValueChange={(value) => {
         if (value === "__none__") {
           setSelected("")
+          onSelect(null)
           return
         }
         setSelected(value)
         const template = templates.data.find((t) => t.id === value)
         if (template) {
-          onSelect(template.body)
+          onSelect({
+            id: template.id,
+            body: template.body,
+            customVariables: extractCustomVariables(template.body),
+          })
         }
       }}
     >

--- a/frontend/src/hooks/useSMSMutations.ts
+++ b/frontend/src/hooks/useSMSMutations.ts
@@ -9,6 +9,13 @@ interface SMSMessageCreate {
   device_id?: string
 }
 
+interface SMSTemplateCreate {
+  recipients: string[]
+  template_id: string
+  variables?: Record<string, string>
+  device_id?: string
+}
+
 export function useSendSMS() {
   const queryClient = useQueryClient()
   const { showSuccessToast, showErrorToast } = useCustomToast()
@@ -16,6 +23,30 @@ export function useSendSMS() {
   return useMutation({
     mutationFn: async (data: SMSMessageCreate) => {
       return await pb.send("/api/sms/send", {
+        method: "POST",
+        body: data,
+      })
+    },
+    onSuccess: () => {
+      showSuccessToast("SMS sent successfully")
+    },
+    onError: (error: Error) => {
+      showErrorToast(error.message || "Failed to send SMS")
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["sms"] })
+      queryClient.invalidateQueries({ queryKey: ["quota"] })
+    },
+  })
+}
+
+export function useSendSMSTemplate() {
+  const queryClient = useQueryClient()
+  const { showSuccessToast, showErrorToast } = useCustomToast()
+
+  return useMutation({
+    mutationFn: async (data: SMSTemplateCreate) => {
+      return await pb.send("/api/sms/send-template", {
         method: "POST",
         body: data,
       })

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -334,7 +334,10 @@
     "useTemplate": "Use a template...",
     "none": "None",
     "body": "Body",
-    "createTemplate": "Create Template"
+    "createTemplate": "Create Template",
+    "templatePreview": "Template preview",
+    "autoFilledHint": "{{name}} and {{phone}} are auto-filled from contacts",
+    "variableLabel": "Value for {{var}}"
   },
   "scheduled": {
     "title": "Scheduled SMS",

--- a/frontend/src/locales/es.json
+++ b/frontend/src/locales/es.json
@@ -334,7 +334,10 @@
     "useTemplate": "Usar una plantilla...",
     "none": "Ninguna",
     "body": "Contenido",
-    "createTemplate": "Crear plantilla"
+    "createTemplate": "Crear plantilla",
+    "templatePreview": "Vista previa de la plantilla",
+    "autoFilledHint": "{{name}} y {{phone}} se completan automáticamente desde los contactos",
+    "variableLabel": "Valor para {{var}}"
   },
   "scheduled": {
     "title": "SMS programados",

--- a/frontend/src/routes/_layout.tsx
+++ b/frontend/src/routes/_layout.tsx
@@ -96,43 +96,41 @@ function Layout() {
 
   return (
     <SidebarProvider>
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:outline-none"
-        >
-          {t("common.skipToContent")}
-        </a>
-        <AppSidebar />
-        <SidebarInset>
-          <AnnouncementBanner />
-          <header className="sticky top-0 z-10 flex h-16 shrink-0 items-center gap-2 border-b bg-background px-4">
-            <SidebarTrigger className="-ml-1 text-muted-foreground" />
-            {pageTitle && (
-              <>
-                <Separator orientation="vertical" className="mx-1 h-4" />
-                <span className="text-sm text-muted-foreground">
-                  {pageTitle}
-                </span>
-              </>
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:outline-none"
+      >
+        {t("common.skipToContent")}
+      </a>
+      <AppSidebar />
+      <SidebarInset>
+        <AnnouncementBanner />
+        <header className="sticky top-0 z-10 flex h-16 shrink-0 items-center gap-2 border-b bg-background px-4">
+          <SidebarTrigger className="-ml-1 text-muted-foreground" />
+          {pageTitle && (
+            <>
+              <Separator orientation="vertical" className="mx-1 h-4" />
+              <span className="text-sm text-muted-foreground">{pageTitle}</span>
+            </>
+          )}
+          <div className="ml-auto flex items-center gap-2">
+            <TopUpPopover />
+            {config.maintenanceMode && (
+              <Badge variant="destructive" className="gap-1.5">
+                <Construction className="size-3" />
+                {t("maintenance.maintenanceMode")}
+              </Badge>
             )}
-            <div className="ml-auto flex items-center gap-2">
-              <TopUpPopover />
-              {config.maintenanceMode && (
-                <Badge variant="destructive" className="gap-1.5">
-                  <Construction className="size-3" />
-                  {t("maintenance.maintenanceMode")}
-                </Badge>
-              )}
-            </div>
-          </header>
-          <main id="main-content" className="flex-1 p-6 md:p-8">
-            <div className="mx-auto max-w-7xl">
-              <Outlet />
-            </div>
-          </main>
-          <Footer />
-        </SidebarInset>
-      </SidebarProvider>
+          </div>
+        </header>
+        <main id="main-content" className="flex-1 p-6 md:p-8">
+          <div className="mx-auto max-w-7xl">
+            <Outlet />
+          </div>
+        </main>
+        <Footer />
+      </SidebarInset>
+    </SidebarProvider>
   )
 }
 

--- a/frontend/src/routes/_layout/contacts.tsx
+++ b/frontend/src/routes/_layout/contacts.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { Plus, Users } from "lucide-react"
-import { Suspense, useMemo } from "react"
-import { useState } from "react"
+import { Suspense, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { DataTable } from "@/components/Common/DataTable"
@@ -37,18 +36,12 @@ function ContactsEmptyState({ onAddContact }: { onAddContact: () => void }) {
   )
 }
 
-function ContactsTableContent({
-  onAddContact,
-}: { onAddContact: () => void }) {
+function ContactsTableContent({ onAddContact }: { onAddContact: () => void }) {
   const { t } = useTranslation()
   const { data: contacts } = useContactListSuspense()
   const { data: groups } = useContactGroupList()
   const columns = useMemo(
-    () =>
-      getColumns(
-        t,
-        ((groups?.data ?? []) as unknown as ContactGroup[]),
-      ),
+    () => getColumns(t, (groups?.data ?? []) as unknown as ContactGroup[]),
     [t, groups],
   )
 


### PR DESCRIPTION
## Summary
- New `POST /api/sms/send-template` endpoint for sending SMS using saved templates with `{{variable}}` interpolation
- Reserved variables `{{name}}` and `{{phone}}` are auto-filled from the user's contacts per recipient
- Custom variables (e.g. `{{code}}`) are validated and provided at send time
- Refactored handler: extracted `resolveRecipients`, `resolveTemplate`, `buildSendResponse` helpers
- Frontend: `TemplateSelect` returns template ID + extracted variables, `SendSMS` shows template preview + dynamic variable inputs
- Separate `useSendSMSTemplate` mutation calling the new endpoint
- Updated `ScheduledSMS` components for the new `TemplateSelect` signature
- i18n keys for template variable UI (en + es)

## Test plan
- [ ] Create a template with `{{name}}` and a custom variable like `{{code}}`
- [ ] Send SMS via template to a contact — verify `{{name}}` is auto-filled
- [ ] Send SMS via template to an unknown number — verify `{{name}}` stays literal
- [ ] Send SMS without template — verify direct body still works
- [ ] Verify missing custom variables return 400 error
- [ ] Verify template ownership (user A can't use user B's template)

🤖 Generated with [Claude Code](https://claude.com/claude-code)