### PR TITLE
Replace deprecated lucide-react icon aliases with canonical v1 names

### DIFF
--- a/frontend/src/components/Admin/SystemSettings.tsx
+++ b/frontend/src/components/Admin/SystemSettings.tsx
@@ -3,7 +3,7 @@ import {
   Check,
   Coins,
   CreditCard,
-  Loader2,
+  LoaderCircle,
   Settings2,
 } from "lucide-react"
 import { useEffect, useState } from "react"
@@ -56,7 +56,7 @@ function SystemSettings() {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-8">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <LoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     )
   }

--- a/frontend/src/components/Devices/AndroidAppDownload.tsx
+++ b/frontend/src/components/Devices/AndroidAppDownload.tsx
@@ -1,4 +1,4 @@
-import { Download, ExternalLink, Loader2, Smartphone } from "lucide-react"
+import { Download, ExternalLink, LoaderCircle, Smartphone } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -64,7 +64,7 @@ export default function AndroidAppDownload() {
         >
           <Button size="sm" disabled={isLoading || !downloadUrl}>
             {isLoading ? (
-              <Loader2 className="size-3.5 animate-spin" />
+              <LoaderCircle className="size-3.5 animate-spin" />
             ) : (
               <Download className="size-3.5" />
             )}

--- a/frontend/src/components/Sidebar/AppSidebar.tsx
+++ b/frontend/src/components/Sidebar/AppSidebar.tsx
@@ -3,7 +3,7 @@ import {
   Contact,
   CreditCard,
   FileText,
-  Home,
+  House,
   Key,
   MessageSquare,
   Smartphone,
@@ -25,7 +25,7 @@ import { type Item, Main } from "./Main"
 import { User } from "./User"
 
 const baseItems: Item[] = [
-  { icon: Home, title: "sidebar.dashboard", path: "/" },
+  { icon: House, title: "sidebar.dashboard", path: "/" },
   { icon: MessageSquare, title: "sidebar.sms", path: "/sms" },
   { icon: FileText, title: "sidebar.templates", path: "/templates" },
   { icon: Clock, title: "sidebar.scheduled", path: "/scheduled" },

--- a/frontend/src/components/Webhooks/TestWebhook.tsx
+++ b/frontend/src/components/Webhooks/TestWebhook.tsx
@@ -1,4 +1,4 @@
-import { FlaskConical, Loader2 } from "lucide-react"
+import { FlaskConical, LoaderCircle } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
@@ -26,7 +26,7 @@ const TestWebhook = ({ webhookId, onSuccess }: TestWebhookProps) => {
       disabled={testMutation.isPending}
     >
       {testMutation.isPending ? (
-        <Loader2 className="animate-spin" />
+        <LoaderCircle className="animate-spin" />
       ) : (
         <FlaskConical />
       )}

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -3,7 +3,7 @@
 import {
   CircleCheckIcon,
   InfoIcon,
-  Loader2Icon,
+  LoaderCircleIcon,
   OctagonXIcon,
   TriangleAlertIcon,
 } from "lucide-react"
@@ -22,7 +22,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
         info: <InfoIcon className="size-4" />,
         warning: <TriangleAlertIcon className="size-4" />,
         error: <OctagonXIcon className="size-4" />,
-        loading: <Loader2Icon className="size-4 animate-spin" />,
+        loading: <LoaderCircleIcon className="size-4 animate-spin" />,
       }}
       style={
         {

--- a/frontend/src/components/ui/spinner.tsx
+++ b/frontend/src/components/ui/spinner.tsx
@@ -1,10 +1,10 @@
-import { Loader2Icon } from "lucide-react"
+import { LoaderCircleIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
 function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
   return (
-    <Loader2Icon
+    <LoaderCircleIcon
       role="status"
       aria-label="Loading"
       className={cn("size-4 animate-spin", className)}

--- a/frontend/src/routes/privacy.tsx
+++ b/frontend/src/routes/privacy.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link as RouterLink } from "@tanstack/react-router"
-import { ArrowLeft, Loader2 } from "lucide-react"
+import { ArrowLeft, LoaderCircle } from "lucide-react"
 
 import useAppConfig from "@/hooks/useAppConfig"
 
@@ -15,7 +15,7 @@ function Privacy() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <LoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     )
   }

--- a/frontend/src/routes/subscription.error.tsx
+++ b/frontend/src/routes/subscription.error.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link as RouterLink } from "@tanstack/react-router"
-import { XCircle } from "lucide-react"
+import { CircleX } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { AuthLayout } from "@/components/Common/AuthLayout"
 import { Button } from "@/components/ui/button"
@@ -22,7 +22,7 @@ function SubscriptionError() {
     <AuthLayout>
       <div className="flex flex-col items-center gap-6 text-center">
         <div className="rounded-full bg-destructive/10 p-4">
-          <XCircle className="h-12 w-12 text-destructive" />
+          <CircleX className="h-12 w-12 text-destructive" />
         </div>
 
         <h1 className="text-2xl">{t("subscription.failed")}</h1>

--- a/frontend/src/routes/subscription.success.tsx
+++ b/frontend/src/routes/subscription.success.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link as RouterLink } from "@tanstack/react-router"
-import { CheckCircle } from "lucide-react"
+import { CircleCheckBig } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { AuthLayout } from "@/components/Common/AuthLayout"
 import { Button } from "@/components/ui/button"
@@ -22,7 +22,7 @@ function SubscriptionSuccess() {
     <AuthLayout>
       <div className="flex flex-col items-center gap-6 text-center">
         <div className="rounded-full bg-green-500/10 p-4">
-          <CheckCircle className="h-12 w-12 text-green-500" />
+          <CircleCheckBig className="h-12 w-12 text-green-500" />
         </div>
 
         <h1 className="text-2xl">{t("subscription.activated")}</h1>

--- a/frontend/src/routes/terms.tsx
+++ b/frontend/src/routes/terms.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link as RouterLink } from "@tanstack/react-router"
-import { ArrowLeft, Loader2 } from "lucide-react"
+import { ArrowLeft, LoaderCircle } from "lucide-react"
 
 import useAppConfig from "@/hooks/useAppConfig"
 
@@ -15,7 +15,7 @@ function Terms() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+        <LoaderCircle className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     )
   }

--- a/frontend/src/routes/verify-email.tsx
+++ b/frontend/src/routes/verify-email.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link as RouterLink } from "@tanstack/react-router"
-import { CheckCircle, Loader2, XCircle } from "lucide-react"
+import { CircleCheckBig, LoaderCircle, CircleX } from "lucide-react"
 import { useTranslation } from "react-i18next"
 import { AuthLayout } from "@/components/Common/AuthLayout"
 import { Button } from "@/components/ui/button"
@@ -45,7 +45,7 @@ function VerifyEmailPending() {
   return (
     <AuthLayout>
       <div className="flex flex-col items-center gap-6 text-center">
-        <Loader2 className="h-16 w-16 animate-spin text-primary" />
+        <LoaderCircle className="h-16 w-16 animate-spin text-primary" />
         <h1 className="text-2xl">{t("auth.verifyingEmail")}</h1>
         <p className="text-muted-foreground">{t("auth.pleaseWait")}</p>
       </div>
@@ -65,7 +65,7 @@ function VerifyEmail() {
       <div className="flex flex-col items-center gap-6 text-center">
         {status === "success" && (
           <>
-            <CheckCircle className="h-16 w-16 text-green-500" />
+            <CircleCheckBig className="h-16 w-16 text-green-500" />
             <h1 className="text-2xl">{t("auth.emailVerified")}</h1>
             <p className="text-muted-foreground">
               {t("auth.emailVerifiedSuccess")}
@@ -78,7 +78,7 @@ function VerifyEmail() {
 
         {status === "error" && (
           <>
-            <XCircle className="h-16 w-16 text-destructive" />
+            <CircleX className="h-16 w-16 text-destructive" />
             <h1 className="text-2xl">{t("auth.verificationFailed")}</h1>
             <p className="text-muted-foreground">
               {errorMessage || t(errorKey)}


### PR DESCRIPTION
## Summary
- Replaces deprecated lucide-react 0.x icon aliases with their canonical v1 names across 11 files
- `CheckCircle` → `CircleCheckBig`, `XCircle` → `CircleX`, `Loader2` → `LoaderCircle`, `Loader2Icon` → `LoaderCircleIcon`, `Home` → `House`
- Vite build verified with zero errors

## Test plan
- [x] `vite build` passes successfully
- [x] No deprecated aliases remain in codebase
- [ ] Visual check: icons render correctly in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)