### PR TITLE
Fix hardcoded 'http://localhost:8090' in deployed container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY frontend/package.json frontend/bun.lock ./
 RUN ["bun", "install", "--frozen-lockfile"]
 
 COPY frontend/ ./
+ENV NODE_ENV=production
 RUN ["bun", "run", "build"]
 
 # Stage 2: Build Go binary


### PR DESCRIPTION
Vite was picking up .env.development; Setting NODE_ENV=production means it will search for .env.production instead;
See:
   1. https://vite.dev/guide/env-and-mode#env-files
   2. https://vite.dev/guide/env-and-mode#node-env-and-modes

fixes #203