### PR TITLE
Bump modem-agent to Go 1.26.5 and golang.org/x/sys v0.47.0

### DIFF
--- a/modem-agent/go.mod
+++ b/modem-agent/go.mod
@@ -1,9 +1,9 @@
 module vendel-modem-agent
 
-go 1.26.1
+go 1.26.5
 
 require github.com/xlab/at v1.0.1-0.20260329105545-b341cce335ba
 
 require gopkg.in/yaml.v3 v3.0.1
 
-require golang.org/x/sys v0.46.0
+require golang.org/x/sys v0.47.0

--- a/modem-agent/go.sum
+++ b/modem-agent/go.sum
@@ -6,8 +6,8 @@ github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5Cc
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/xlab/at v1.0.1-0.20260329105545-b341cce335ba h1:I6UGxAGnLi3WPzxPjfHuTXFFfi5On1bEchv9KDKmVXM=
 github.com/xlab/at v1.0.1-0.20260329105545-b341cce335ba/go.mod h1:OtlMJWS58jKIDFelst6wEicoaTcw0/+e1OmByL7feo4=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Alinea `modem-agent` con el backend tras #217.

- Directiva `go` 1.26.1 → **1.26.5** (mínimo que adoptó PocketBase upstream por los fixes de seguridad de Go 1.26.5; el workflow de release usa `go-version-file`)
- `golang.org/x/sys` v0.46.0 → **v0.47.0**

Las otras dos dependencias se quedan como están: `gopkg.in/yaml.v3` v3.0.1 es la última, y `github.com/xlab/at` ya está fijado en una pseudo-versión de master por delante de su último tag (v1.0.0).

## Verificación

No hay workflow de tests para `modem-agent` (`test.yml` filtra por `backend/**`), pero el autobuild de CodeQL sí compila este módulo — `Found 2 go.mod files in: backend/go.mod, modem-agent/go.mod` — así que **Analyze (go)** en este PR es la comprobación de que compila. Los hashes de `go.sum` vienen de `sum.golang.org`.